### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/com/explodingpixels/border/FocusStateMatteBorder.java
+++ b/src/com/explodingpixels/border/FocusStateMatteBorder.java
@@ -11,6 +11,8 @@ import com.explodingpixels.widgets.WindowUtils;
 
 public class FocusStateMatteBorder extends MatteBorder {
 
+    private static final long serialVersionUID = 1L;
+    
     private final Color fFocusedColor;
 
     private final Color fUnfocusedColor;

--- a/src/com/explodingpixels/macwidgets/PreferencesTabBar.java
+++ b/src/com/explodingpixels/macwidgets/PreferencesTabBar.java
@@ -33,6 +33,8 @@ public class PreferencesTabBar {
 
     public void addTab(String title, Icon icon, ActionListener listener) {
         AbstractButton button = new JToggleButton(title, icon) {
+            private static final long serialVersionUID = 1L;
+            
             @Override
             public void updateUI() {
                 setUI(new PreferencesTabBarButtonUI());

--- a/src/com/explodingpixels/macwidgets/SourceList.java
+++ b/src/com/explodingpixels/macwidgets/SourceList.java
@@ -805,6 +805,8 @@ public class SourceList {
     // Custom JTree implementation that always returns SourceListTreeUI delegate. /////////////////
 
     private class CustomJTree extends JTree {
+        private static final long serialVersionUID = 1L;
+        
         public CustomJTree(TreeModel newModel) {
             super(newModel);
             ToolTipManager.sharedInstance().registerComponent(this);

--- a/src/com/explodingpixels/macwidgets/SourceListCountBadgeRenderer.java
+++ b/src/com/explodingpixels/macwidgets/SourceListCountBadgeRenderer.java
@@ -72,6 +72,8 @@ public class SourceListCountBadgeRenderer {
 
     private class CustomJLabel extends JLabel {
 
+        private static final long serialVersionUID = 1L;
+        
         private Color getSelectedBadgeColor() {
             return fSelectedColor;
         }

--- a/src/com/explodingpixels/macwidgets/plaf/SourceListTreeUI.java
+++ b/src/com/explodingpixels/macwidgets/plaf/SourceListTreeUI.java
@@ -326,6 +326,8 @@ public class SourceListTreeUI extends BasicTreeUI {
 
     private Action createNextAction() {
         return new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             public void actionPerformed(ActionEvent e) {
                 int selectedRow = tree.getLeadSelectionRow();
                 int rowToSelect = selectedRow + 1;
@@ -343,6 +345,8 @@ public class SourceListTreeUI extends BasicTreeUI {
 
     private Action createPreviousAction() {
         return new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             public void actionPerformed(ActionEvent e) {
                 int selectedRow = tree.getLeadSelectionRow();
                 int rowToSelect = selectedRow - 1;
@@ -529,6 +533,8 @@ public class SourceListTreeUI extends BasicTreeUI {
     // SourceListTreeSelectionModel implementation. ///////////////////////////////////////////////
 
     private class SourceListTreeSelectionModel extends DefaultTreeSelectionModel {
+        private static final long serialVersionUID = 1L;
+
         public SourceListTreeSelectionModel() {
             setSelectionMode(TreeSelectionModel.SINGLE_TREE_SELECTION);
         }

--- a/src/com/explodingpixels/painter/CompoundPainter.java
+++ b/src/com/explodingpixels/painter/CompoundPainter.java
@@ -16,6 +16,7 @@ public class CompoundPainter<T> implements MacWidgetsPainter<T> {
      * @param painters the {@code Painter}s to delegate to.
      */
     @SafeVarargs
+    @SuppressWarnings("varargs")
     public CompoundPainter(MacWidgetsPainter<T>... painters) {
         fPainters = painters;
     }

--- a/src/com/explodingpixels/swingx/EPButton.java
+++ b/src/com/explodingpixels/swingx/EPButton.java
@@ -12,6 +12,8 @@ import com.explodingpixels.painter.MacWidgetsPainter;
 
 public class EPButton extends JButton {
 
+    private static final long serialVersionUID = 1L;
+    
     private MacWidgetsPainter<AbstractButton> fBackgroundPainter;
 
     public EPButton() {

--- a/src/com/explodingpixels/swingx/EPPanel.java
+++ b/src/com/explodingpixels/swingx/EPPanel.java
@@ -10,6 +10,8 @@ import com.explodingpixels.painter.MacWidgetsPainter;
 
 public class EPPanel extends JPanel {
 
+    private static final long serialVersionUID = 1L;
+    
     private MacWidgetsPainter<Component> fBackgroundPainter;
 
     public EPPanel() {

--- a/src/com/explodingpixels/swingx/EPToggleButton.java
+++ b/src/com/explodingpixels/swingx/EPToggleButton.java
@@ -12,6 +12,8 @@ import com.explodingpixels.painter.MacWidgetsPainter;
 
 public class EPToggleButton extends JToggleButton {
 
+    private static final long serialVersionUID = 1L;
+    
     private MacWidgetsPainter<AbstractButton> fBackgroundPainter;
 
     public EPToggleButton() {

--- a/src/com/explodingpixels/widgets/ImageBasedJComponent.java
+++ b/src/com/explodingpixels/widgets/ImageBasedJComponent.java
@@ -8,6 +8,8 @@ import com.explodingpixels.swingx.EPPanel;
 
 public class ImageBasedJComponent extends EPPanel {
 
+    private static final long serialVersionUID = 1L;
+
     private final ImagePainter fPainter;
 
     public ImageBasedJComponent(Image image) {

--- a/src/com/explodingpixels/widgets/ImageButton.java
+++ b/src/com/explodingpixels/widgets/ImageButton.java
@@ -18,6 +18,8 @@ import javax.swing.plaf.basic.BasicButtonUI;
  */
 public class ImageButton extends JButton {
 
+    private static final long serialVersionUID = 1L;
+    
     // create a static index for the alpha channel of a raster image. i'm not exactly sure where
     // it's specified that red = channel 0, green = channel 1, blue = channel 2, and
     // alpha = channel 3, but this have been the values i've observed.

--- a/src/com/explodingpixels/widgets/PopdownButton.java
+++ b/src/com/explodingpixels/widgets/PopdownButton.java
@@ -49,7 +49,7 @@ public class PopdownButton {
 
         // this is a trick to get hold of the client property which prevents
         // closing of the popup when the button is pressed.
-        JComboBox box = new JComboBox();
+        JComboBox<?> box = new JComboBox<>();
         Object preventHide = box.getClientProperty("doNotCancelPopup");
         fButton.putClientProperty("doNotCancelPopup", preventHide);
     }

--- a/src/com/explodingpixels/widgets/PopupButton.java
+++ b/src/com/explodingpixels/widgets/PopupButton.java
@@ -190,6 +190,8 @@ public class PopupButton<E> {
 
 	private static class CustomJButton extends JButton {
 
+	    private static final long serialVersionUID = 1L;
+	    
 		@Override
 		protected void paintComponent(Graphics g) {
 			super.paintComponent(g);

--- a/src/com/explodingpixels/widgets/TableHeaderUtils.java
+++ b/src/com/explodingpixels/widgets/TableHeaderUtils.java
@@ -34,6 +34,8 @@ public class TableHeaderUtils {
      */
     public static JComponent createCornerComponent(final JTable table) {
         return new JComponent() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             protected void paintComponent(Graphics g) {
                 paintHeader(g, table, 0, getWidth());
@@ -79,6 +81,8 @@ public class TableHeaderUtils {
      */
     private static Border createTableHeaderEmptyColumnPainter(final JTable table) {
         return new AbstractBorder() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void paintBorder(Component c, Graphics g, int x, int y, int width, int height) {
                 // if this JTableHeader is parented in a JViewport, then paint the table header

--- a/src/com/explodingpixels/widgets/TrackingSpacer.java
+++ b/src/com/explodingpixels/widgets/TrackingSpacer.java
@@ -12,6 +12,8 @@ import javax.swing.JComponent;
  */
 public class TrackingSpacer extends JComponent {
 
+    private static final long serialVersionUID = 1L;
+    
     private final JComponent fComponent;
     private final TrackingDimension fTrackingDimension;
     private final int fDelta;

--- a/src/com/explodingpixels/widgets/plaf/EPComboPopup.java
+++ b/src/com/explodingpixels/widgets/plaf/EPComboPopup.java
@@ -34,7 +34,7 @@ import javax.swing.plaf.basic.ComboPopup;
  */
 public class EPComboPopup implements ComboPopup {
 
-    private final JComboBox fComboBox;
+    private final JComboBox<?> fComboBox;
     private JPopupMenu fPopupMenu = new JPopupMenu();
     private Font fFont;
     private ComboBoxVerticalCenterProvider fComboBoxVerticalCenterProvider =
@@ -42,7 +42,7 @@ public class EPComboPopup implements ComboPopup {
 
     private static final int LEFT_SHIFT = 5;
 
-    public EPComboPopup(JComboBox comboBox) {
+    public EPComboPopup(JComboBox<?> comboBox) {
         fComboBox = comboBox;
         fFont = comboBox.getFont();
         fPopupMenu.addPopupMenuListener(createPopupMenuListener());
@@ -202,7 +202,7 @@ public class EPComboPopup implements ComboPopup {
      *
      * @return null.
      */
-    public JList getList() {
+    public JList<?> getList() {
         return null;
     }
 
@@ -242,13 +242,13 @@ public class EPComboPopup implements ComboPopup {
     // An interface to allow a third-party to provide the center of a given compoennt. ////////////
 
     public interface ComboBoxVerticalCenterProvider {
-        int provideCenter(JComboBox comboBox);
+        int provideCenter(JComboBox<?> comboBox);
     }
 
     // A default implementation of ComboBoxVerticalCenterProvider. ////////////////////////////////
 
     private static class DefaultVerticalCenterProvider implements ComboBoxVerticalCenterProvider {
-        public int provideCenter(JComboBox comboBox) {
+        public int provideCenter(JComboBox<?> comboBox) {
             return comboBox.getHeight() / 2;
         }
     }

--- a/src/mediathek/MediathekGui.java
+++ b/src/mediathek/MediathekGui.java
@@ -61,6 +61,8 @@ import mediathek.tool.MVMessageDialog;
 
 public class MediathekGui extends JFrame {
 
+    private static final long serialVersionUID = 1L;
+    
     private final Daten daten;
 //    private final SpacerIcon spacerIcon = new SpacerIcon(30);
     private final JSpinner jSpinnerAnzahl = new JSpinner(new SpinnerNumberModel(1, 1, 9, 1));
@@ -252,6 +254,8 @@ public class MediathekGui extends JFrame {
         final JRootPane rootPane = getRootPane();
         rootPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_F, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "mac-f");
         rootPane.getActionMap().put("mac-f", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+            
             @Override
             public void actionPerformed(ActionEvent e) {
                 setFocusSuchfeld();

--- a/src/mediathek/config/Daten.java
+++ b/src/mediathek/config/Daten.java
@@ -359,7 +359,7 @@ public class Daten {
                 Files.deleteIfExists(path1);
             } catch (IOException e) {
                 SysMsg.sysMsg("Die Einstellungen konnten nicht zurückgesetzt werden.");
-                MVMessageDialog.showMessageDialog(this.mediathekGui, "Die Einstellungen konnten nicht zurückgesetzt werden.\n"
+                MVMessageDialog.showMessageDialog(Daten.mediathekGui, "Die Einstellungen konnten nicht zurückgesetzt werden.\n"
                         + "Sie müssen jetzt das Programm beenden und dann den Ordner:\n"
                         + getSettingsDirectory_String() + "\n"
                         + "von Hand löschen und dann das Programm wieder starten.\n\n"

--- a/src/mediathek/controller/MVUsedUrls.java
+++ b/src/mediathek/controller/MVUsedUrls.java
@@ -45,7 +45,8 @@ public class MVUsedUrls {
         this.notifyEvent = notifyEvent;
         listeUrlsSortDate = new LinkedList<>();
         listeUrls = new HashSet<String>() {
-
+            private static final long serialVersionUID = 1L;
+            
             @Override
             public void clear() {
                 listeUrlsSortDate.clear();

--- a/src/mediathek/daten/ListeAbo.java
+++ b/src/mediathek/daten/ListeAbo.java
@@ -35,9 +35,11 @@ import mediathek.tool.TModelAbo;
 
 public class ListeAbo extends LinkedList<DatenAbo> {
 
-    Daten daten;
-    final String[] LEER = {""};
-    String[] titel, thema, irgendwo;
+    private static final long serialVersionUID = 1L;
+
+    private Daten daten;
+    private final String[] LEER = {""};
+    private String[] titel, thema, irgendwo;
 
     public ListeAbo(Daten ddaten) {
         daten = ddaten;

--- a/src/mediathek/daten/ListeBlacklist.java
+++ b/src/mediathek/daten/ListeBlacklist.java
@@ -34,6 +34,8 @@ import java.util.stream.Collectors;
 
 public class ListeBlacklist extends LinkedList<DatenBlacklist> {
 
+    private static final long serialVersionUID = 1L;
+
     private long days = 0;
     private long now;
     private boolean doNotShowFutureFilms, doNotShowGeoBlockedFilms;

--- a/src/mediathek/daten/ListeDownloads.java
+++ b/src/mediathek/daten/ListeDownloads.java
@@ -37,6 +37,8 @@ import mediathek.tool.TModelDownload;
 
 public class ListeDownloads extends LinkedList<DatenDownload> {
 
+    private static final long serialVersionUID = 1L;
+
     private final Daten daten;
     private final LinkedList<DatenDownload> aktivDownloads = new LinkedList<>();
 

--- a/src/mediathek/daten/ListeDownloads.java
+++ b/src/mediathek/daten/ListeDownloads.java
@@ -342,10 +342,10 @@ public class ListeDownloads extends LinkedList<DatenDownload> {
 
     @SuppressWarnings("unchecked")
     public synchronized void setModelProgress(TModelDownload tModel) {
-        Iterator<List> it = tModel.getDataVector().iterator();
+        Iterator<List<?>> it = tModel.getDataVector().iterator();
         int row = 0;
         while (it.hasNext()) {
-            List l = it.next();
+            List<?> l = it.next();
             DatenDownload datenDownload = (DatenDownload) l.get(DatenDownload.DOWNLOAD_REF);
             if (datenDownload.start != null) {
                 if (datenDownload.start.status == Start.STATUS_RUN) {
@@ -361,7 +361,7 @@ public class ListeDownloads extends LinkedList<DatenDownload> {
 
     @SuppressWarnings("unchecked")
     public synchronized void setModelProgressAlleStart(TModelDownload tModel) {
-        for (List l : (Iterable<List>) tModel.getDataVector()) {
+        for (List<Object> l : (Iterable<List<Object>>) tModel.getDataVector()) {
             DatenDownload datenDownload = (DatenDownload) l.get(DatenDownload.DOWNLOAD_REF);
             if (datenDownload.start != null) {
                 l.set(DatenDownload.DOWNLOAD_RESTZEIT, datenDownload.getTextRestzeit());

--- a/src/mediathek/daten/ListeMediaDB.java
+++ b/src/mediathek/daten/ListeMediaDB.java
@@ -206,7 +206,6 @@ public class ListeMediaDB extends LinkedList<DatenMediaDB> {
             bw.newLine();
             //
             bw.flush();
-            bw.close();
         } catch (Exception ex) {
             SwingUtilities.invokeLater(() -> {
                 MVMessageDialog.showMessageDialog(null, "Datei konnte nicht geschrieben werden!",

--- a/src/mediathek/daten/ListeMediaDB.java
+++ b/src/mediathek/daten/ListeMediaDB.java
@@ -39,6 +39,8 @@ import mediathek.tool.TModelMediaDB;
 
 public class ListeMediaDB extends LinkedList<DatenMediaDB> {
 
+    private static final long serialVersionUID = 1L;
+
     public final static String TRENNER = "  |###|  ";
     public final String FILE_SEPERATOR_MEDIA_PATH = "<>";
     private boolean makeIndex = false;

--- a/src/mediathek/daten/ListeMediaPath.java
+++ b/src/mediathek/daten/ListeMediaPath.java
@@ -26,6 +26,8 @@ import mediathek.tool.TModel;
 
 public class ListeMediaPath extends LinkedList<DatenMediaPath> {
 
+    private static final long serialVersionUID = 1L;
+
     public boolean addSave(DatenMediaPath dmp) {
         while (countSave() > 10) {
             removeFirstSave();

--- a/src/mediathek/daten/ListeProg.java
+++ b/src/mediathek/daten/ListeProg.java
@@ -25,6 +25,8 @@ import mediathek.tool.TModel;
 
 public class ListeProg extends LinkedList<DatenProg> {
 
+    private static final long serialVersionUID = 1L;
+
     public DatenProg remove(String name) {
         DatenProg ret = null;
         Iterator<DatenProg> it = this.iterator();

--- a/src/mediathek/daten/ListePset.java
+++ b/src/mediathek/daten/ListePset.java
@@ -36,6 +36,8 @@ import mediathek.tool.TModel;
 public class ListePset extends LinkedList<DatenPset> {
     // Liste aller Programmsets
 
+    private static final long serialVersionUID = 1L;
+
     public static final String MUSTER_PFAD_ZIEL = "ZIELPFAD";
     public static final String MUSTER_PFAD_VLC = "PFAD_VLC";
     public static final String MUSTER_PFAD_FLV = "PFAD_FLVSTREAMER";

--- a/src/mediathek/daten/ListePsetVorlagen.java
+++ b/src/mediathek/daten/ListePsetVorlagen.java
@@ -42,6 +42,8 @@ import mediathek.tool.TModel;
 
 public class ListePsetVorlagen extends LinkedList<String[]> {
 
+    private static final long serialVersionUID = 1L;
+
     public static final String BS_WIN_32 = "Windows-32Bit";
     public static final String BS_WIN_64 = "Windows-64Bit";
     public static final String BS_LINUX = "Linux";

--- a/src/mediathek/filmlisten/FilmeLaden.java
+++ b/src/mediathek/filmlisten/FilmeLaden.java
@@ -124,8 +124,8 @@ public class FilmeLaden {
     public void loadFilmlistDialog(Daten daten, boolean manuell) {
         if (manuell || GuiFunktionen.getImportArtFilme() == Konstanten.UPDATE_FILME_AUS) {
             // Dialog zum Laden der Filme anzeigen
-            DialogLeer dialog = new DialogLeer(daten.mediathekGui, true);
-            dialog.init("Einstellungen zum Laden der Filme", new PanelFilmlisteLaden(daten, daten.mediathekGui));
+            DialogLeer dialog = new DialogLeer(Daten.mediathekGui, true);
+            dialog.init("Einstellungen zum Laden der Filme", new PanelFilmlisteLaden(daten, Daten.mediathekGui));
             dialog.setVisible(true);
         } else {
             // Filme werden automatisch geladen

--- a/src/mediathek/gui/AboutPanel.java
+++ b/src/mediathek/gui/AboutPanel.java
@@ -38,6 +38,8 @@ import mediathek.tool.UrlHyperlinkAction;
 
 public class AboutPanel extends javax.swing.JPanel {
 
+    private static final long serialVersionUID = 1L;
+    
     private MarqueePane marqueePane;
     private final JFrame parentFrame;
     final private Color greyColor = new Color(159, 159, 159);
@@ -416,7 +418,8 @@ public class AboutPanel extends javax.swing.JPanel {
     }// </editor-fold>//GEN-END:initComponents
 
     private class WebsiteHyperlinkAction extends AbstractAction {
-
+        private static final long serialVersionUID = 1L;
+        
         public WebsiteHyperlinkAction() throws URISyntaxException {
             putValue(SHORT_DESCRIPTION, Konstanten.ADRESSE_WEBSITE);
             putValue(LONG_DESCRIPTION, Konstanten.ADRESSE_WEBSITE);
@@ -432,7 +435,8 @@ public class AboutPanel extends javax.swing.JPanel {
     }
 
     private class DonationHyperlinkAction extends AbstractAction {
-
+        private static final long serialVersionUID = 1L;
+        
         public DonationHyperlinkAction() throws URISyntaxException {
             putValue(SHORT_DESCRIPTION, Konstanten.ADRESSE_DONATION);
             putValue(LONG_DESCRIPTION, Konstanten.ADRESSE_DONATION);
@@ -448,7 +452,8 @@ public class AboutPanel extends javax.swing.JPanel {
     }
 
     private class ForumHyperlinkAction extends AbstractAction {
-
+        private static final long serialVersionUID = 1L;
+        
         public ForumHyperlinkAction() throws URISyntaxException {
             putValue(SHORT_DESCRIPTION, Konstanten.ADRESSE_FORUM);
             putValue(LONG_DESCRIPTION, Konstanten.ADRESSE_FORUM);
@@ -464,7 +469,8 @@ public class AboutPanel extends javax.swing.JPanel {
     }
 
     private class AnleitungHyperlinkAction extends AbstractAction {
-
+        private static final long serialVersionUID = 1L;
+        
         public AnleitungHyperlinkAction() throws URISyntaxException {
             putValue(SHORT_DESCRIPTION, Konstanten.ADRESSE_ANLEITUNG);
             putValue(LONG_DESCRIPTION, Konstanten.ADRESSE_ANLEITUNG);

--- a/src/mediathek/gui/GuiAbo.java
+++ b/src/mediathek/gui/GuiAbo.java
@@ -39,6 +39,8 @@ import mediathek.tool.*;
 
 public class GuiAbo extends PanelVorlage {
 
+    private static final long serialVersionUID = 1L;
+    
     private ToolBar toolBar;
 
     public GuiAbo(Daten d, JFrame parentComponent) {
@@ -123,6 +125,8 @@ public class GuiAbo extends PanelVorlage {
                 true /*Icon*/, MVConfig.Configs.SYSTEM_TAB_ABO_LINEBREAK));
         this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_T, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "tabelle");
         this.getActionMap().put("tabelle", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 tabelle.requestFocusSelelct(jScrollPane1);
@@ -133,6 +137,7 @@ public class GuiAbo extends PanelVorlage {
         InputMap im = tabelle.getInputMap();
         im.put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), "aendern");
         am.put("aendern", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
 
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -142,6 +147,7 @@ public class GuiAbo extends PanelVorlage {
         //löschen
         im.put(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0), "loeschen");
         am.put("loeschen", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
 
             @Override
             public void actionPerformed(ActionEvent e) {

--- a/src/mediathek/gui/GuiDebug.java
+++ b/src/mediathek/gui/GuiDebug.java
@@ -44,6 +44,8 @@ import mediathek.gui.dialogEinstellungen.PanelFilmlisten;
 
 public class GuiDebug extends JPanel {
 
+    private static final long serialVersionUID = 1L;
+    
     private final JButton[] buttonSender;
     private final String[] sender;
     private Daten daten;

--- a/src/mediathek/gui/GuiDebug.java
+++ b/src/mediathek/gui/GuiDebug.java
@@ -716,7 +716,7 @@ public class GuiDebug extends JPanel {
         public void actionPerformed(ActionEvent e) {
             //we can use native chooser on Mac...
             if (SystemInfo.isMacOSX()) {
-                FileDialog chooser = new FileDialog(daten.mediathekGui, "Pfad");
+                FileDialog chooser = new FileDialog(Daten.mediathekGui, "Pfad");
                 chooser.setMode(FileDialog.SAVE);
                 chooser.setVisible(true);
                 if (chooser.getFile() != null) {

--- a/src/mediathek/gui/GuiDownloads.java
+++ b/src/mediathek/gui/GuiDownloads.java
@@ -51,7 +51,9 @@ import mediathek.tool.*;
 
 public class GuiDownloads extends PanelVorlage {
 
-//    private final MVFilmInfo filmInfoHud;
+    private static final long serialVersionUID = 1L;
+    
+    //    private final MVFilmInfo filmInfoHud;
     private long lastUpdate = 0;
     private boolean onlyAbos = false;
     private boolean onlyDownloads = false;
@@ -93,6 +95,7 @@ public class GuiDownloads extends PanelVorlage {
             im.put(KeyStroke.getKeyStroke(KeyEvent.VK_F4, 0), "einstellungen");
             ActionMap am = cbDisplayCategories.getActionMap();
             am.put("einstellungen", new AbstractAction() {
+                private static final long serialVersionUID = 1L;
 
                 @Override
                 public void actionPerformed(ActionEvent e) {
@@ -214,6 +217,7 @@ public class GuiDownloads extends PanelVorlage {
         InputMap im = tabelle.getInputMap();
         im.put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), "aendern");
         am.put("aendern", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
 
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -222,6 +226,7 @@ public class GuiDownloads extends PanelVorlage {
         });
         im.put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), "loeschen");
         am.put("loeschen", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
 
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -231,6 +236,8 @@ public class GuiDownloads extends PanelVorlage {
 
         this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_T, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "tabelle");
         this.getActionMap().put("tabelle", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 tabelle.requestFocusSelelct(jScrollPane1);
@@ -238,6 +245,8 @@ public class GuiDownloads extends PanelVorlage {
         });
         this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_D, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "download");
         this.getActionMap().put("download", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 filmStartenWiederholenStoppen(false, true /* starten */);
@@ -245,6 +254,8 @@ public class GuiDownloads extends PanelVorlage {
         });
         this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_I, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "info");
         this.getActionMap().put("info", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 if (!Daten.filmInfo.isVisible()) {
@@ -255,6 +266,8 @@ public class GuiDownloads extends PanelVorlage {
 
         this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_U, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "url-copy");
         this.getActionMap().put("url-copy", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 int row = tabelle.getSelectedRow();
@@ -267,6 +280,8 @@ public class GuiDownloads extends PanelVorlage {
 
         this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_M, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "mediensammlung");
         this.getActionMap().put("mediensammlung", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 int row = tabelle.getSelectedRow();
@@ -284,6 +299,8 @@ public class GuiDownloads extends PanelVorlage {
         });
         this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_G, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "gesehen");
         this.getActionMap().put("gesehen", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 filmGesehen();
@@ -291,6 +308,8 @@ public class GuiDownloads extends PanelVorlage {
         });
         this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_N, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "ungesehen");
         this.getActionMap().put("ungesehen", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 filmUngesehen();

--- a/src/mediathek/gui/GuiFilme.java
+++ b/src/mediathek/gui/GuiFilme.java
@@ -55,6 +55,8 @@ import static mediathek.tool.MVTable.*;
 
 public class GuiFilme extends PanelVorlage {
 
+    private static final long serialVersionUID = 1L;
+
     private JButton buttonArray[];
 //    private static final int FILTER_ZEIT_STARTWERT = 15;
 //    private static final int FILTER_DAUER_STARTWERT = 0;
@@ -72,6 +74,8 @@ public class GuiFilme extends PanelVorlage {
         jScrollPaneFilter.getVerticalScrollBar().setUnitIncrement(16);
         jPanelFilter.setLayout(new BorderLayout());
         mVFilterPanel = new MVFilterPanel(parentComponent, daten) {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void mvFfilter(int i) {
                 setFilterProfile(i);
@@ -88,6 +92,8 @@ public class GuiFilme extends PanelVorlage {
             }
         };
         mVFilterFrame = new MVFilterFrame(d) {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void mvFfilter(int i) {
                 setFilterProfile(i);
@@ -209,6 +215,8 @@ public class GuiFilme extends PanelVorlage {
         });
         Daten.mediathekGui.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "sender");
         Daten.mediathekGui.getRootPane().getActionMap().put("sender", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
 
@@ -221,6 +229,8 @@ public class GuiFilme extends PanelVorlage {
         });
         this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_P, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "abspielen");
         this.getActionMap().put("abspielen", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 playFilm();
@@ -228,6 +238,8 @@ public class GuiFilme extends PanelVorlage {
         });
         this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_D, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "download");
         this.getActionMap().put("download", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 saveFilm();
@@ -235,6 +247,8 @@ public class GuiFilme extends PanelVorlage {
         });
         this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_T, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "tabelle");
         this.getActionMap().put("tabelle", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 tabelle.requestFocusSelelct(jScrollPane1);
@@ -242,6 +256,8 @@ public class GuiFilme extends PanelVorlage {
         });
         this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_I, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "info");
         this.getActionMap().put("info", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 if (!Daten.filmInfo.isVisible()) {
@@ -252,6 +268,8 @@ public class GuiFilme extends PanelVorlage {
 
         this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_U, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "url-copy");
         this.getActionMap().put("url-copy", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 Optional<DatenFilm> filmSelection = getCurrentlySelectedFilm();
@@ -268,6 +286,8 @@ public class GuiFilme extends PanelVorlage {
             this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_H, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "url-hd-copy");
         }
         this.getActionMap().put("url-hd-copy", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 Optional<DatenFilm> filmSelection = getCurrentlySelectedFilm();
@@ -280,6 +300,8 @@ public class GuiFilme extends PanelVorlage {
 
         this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_K, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "url-k-copy");
         this.getActionMap().put("url-k-copy", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 Optional<DatenFilm> filmSelection = getCurrentlySelectedFilm();
@@ -292,6 +314,8 @@ public class GuiFilme extends PanelVorlage {
 
         this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_M, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "mediensammlung");
         this.getActionMap().put("mediensammlung", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 Optional<DatenFilm> filmSelection = getCurrentlySelectedFilm();
@@ -305,6 +329,8 @@ public class GuiFilme extends PanelVorlage {
         });
         this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_G, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "gesehen");
         this.getActionMap().put("gesehen", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 filmGesehen();
@@ -312,6 +338,8 @@ public class GuiFilme extends PanelVorlage {
         });
         this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_N, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "ungesehen");
         this.getActionMap().put("ungesehen", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 filmUngesehen();
@@ -322,6 +350,7 @@ public class GuiFilme extends PanelVorlage {
         InputMap im = tabelle.getInputMap();
         im.put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), "film_starten");
         am.put("film_starten", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
 
             @Override
             public void actionPerformed(ActionEvent e) {

--- a/src/mediathek/gui/GuiFilme.java
+++ b/src/mediathek/gui/GuiFilme.java
@@ -1878,7 +1878,7 @@ public class GuiFilme extends PanelVorlage {
                             DatenAbo datenAbo;
                             if ((datenAbo = Daten.listeAbo.getAboFuerFilm_schnell(film, false /*ohne Länge*/)) != null) {
                                 //gibts schon, dann löschen
-                                DialogEditAbo dialog = new DialogEditAbo(daten.mediathekGui, true, daten, datenAbo, false/*onlyOne*/);
+                                DialogEditAbo dialog = new DialogEditAbo(Daten.mediathekGui, true, daten, datenAbo, false/*onlyOne*/);
                                 dialog.setVisible(true);
                                 if (dialog.ok) {
                                     Daten.listeAbo.aenderungMelden();

--- a/src/mediathek/gui/GuiMeldungen.java
+++ b/src/mediathek/gui/GuiMeldungen.java
@@ -34,7 +34,9 @@ import mediathek.gui.dialogEinstellungen.PanelMeldungen;
  */
 public class GuiMeldungen extends PanelVorlage {
 
-    JSplitPane splitPane = null;
+    private static final long serialVersionUID = 1L;
+    
+    private JSplitPane splitPane = null;
 
     public GuiMeldungen(Daten d, JFrame parentComponent) {
         super(d, parentComponent);

--- a/src/mediathek/gui/HelpDialog.java
+++ b/src/mediathek/gui/HelpDialog.java
@@ -31,6 +31,8 @@ import mediathek.tool.EscBeenden;
 
 public class HelpDialog extends javax.swing.JDialog {
 
+    private static final long serialVersionUID = 1L;
+
     private final JFrame parentFrame;
 
     public HelpDialog(JFrame parent, Daten daten) {
@@ -63,6 +65,8 @@ public class HelpDialog extends javax.swing.JDialog {
 
     private class CloseDialogAction extends AbstractAction {
 
+        private static final long serialVersionUID = 1L;
+        
         private final JDialog dlg;
 
         public CloseDialogAction(JDialog dlg) {

--- a/src/mediathek/gui/HelpPanel.java
+++ b/src/mediathek/gui/HelpPanel.java
@@ -34,6 +34,8 @@ import mediathek.tool.*;
 
 public class HelpPanel extends javax.swing.JPanel {
 
+    private static final long serialVersionUID = 1L;
+
     private Daten daten;
     private JFrame parent;
 

--- a/src/mediathek/gui/MVBandwidthMonitorLWin.java
+++ b/src/mediathek/gui/MVBandwidthMonitorLWin.java
@@ -43,7 +43,7 @@ public class MVBandwidthMonitorLWin extends javax.swing.JPanel {
 
     private double counter = 0; // double sonst "läuft" die Chart nicht
     private Trace2DLtd m_trace = new Trace2DLtd(300);
-    private IAxis x_achse = null;
+    private IAxis<?> x_achse = null;
     private boolean stopBeob = false;
     private JDialog jDialog = null;
     private JFrame parent = null;
@@ -94,7 +94,7 @@ public class MVBandwidthMonitorLWin extends javax.swing.JPanel {
         x_achse.setMajorTickSpacing(10);
         x_achse.setMinorTickSpacing(1);
 
-        IAxis y_achse = chart.getAxisY();
+        IAxis<?> y_achse = chart.getAxisY();
         y_achse.getAxisTitle().setTitle("");
         y_achse.setPaintScale(true);
         y_achse.setVisible(true);
@@ -421,7 +421,6 @@ public class MVBandwidthMonitorLWin extends javax.swing.JPanel {
         }
     }
 
-    @SuppressWarnings("unchecked")
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
 

--- a/src/mediathek/gui/MVBandwidthMonitorLWin.java
+++ b/src/mediathek/gui/MVBandwidthMonitorLWin.java
@@ -39,6 +39,8 @@ import mediathek.tool.GuiFunktionen;
 
 public class MVBandwidthMonitorLWin extends javax.swing.JPanel {
 
+    private static final long serialVersionUID = 1L;
+
     private double counter = 0; // double sonst "läuft" die Chart nicht
     private Trace2DLtd m_trace = new Trace2DLtd(300);
     private IAxis x_achse = null;

--- a/src/mediathek/gui/MVBandwidthMonitorOSX.java
+++ b/src/mediathek/gui/MVBandwidthMonitorOSX.java
@@ -28,7 +28,7 @@ public class MVBandwidthMonitorOSX {
     private double counter = 0; // double sonst "läuft" die Chart nicht
     private JDialog hudDialog = null;
     private final Trace2DLtd m_trace = new Trace2DLtd(300);
-    private IAxis x_achse = null;
+    private IAxis<?> x_achse = null;
 
     /**
      * Timer for collecting sample data.
@@ -71,7 +71,7 @@ public class MVBandwidthMonitorOSX {
         x_achse.setMajorTickSpacing(10);
         x_achse.setMinorTickSpacing(1);
 
-        IAxis y_achse = chart.getAxisY();
+        IAxis<?> y_achse = chart.getAxisY();
         y_achse.getAxisTitle().setTitle("");
         y_achse.setPaintScale(true);
         y_achse.setVisible(true);

--- a/src/mediathek/gui/MVFilmInformationLWin.java
+++ b/src/mediathek/gui/MVFilmInformationLWin.java
@@ -39,6 +39,8 @@ import org.jdesktop.swingx.JXHyperlink;
 
 public class MVFilmInformationLWin extends javax.swing.JDialog implements MVFilmInfo {
 
+    private static final long serialVersionUID = 1L;
+
     private JXHyperlink lblUrlThemaField;
     private JXHyperlink lblUrlSubtitle;
     private JTextArea textAreaBeschreibung;

--- a/src/mediathek/gui/MVFilterFrame.java
+++ b/src/mediathek/gui/MVFilterFrame.java
@@ -40,9 +40,11 @@ import mediathek.tool.TextCopyPaste;
 
 public class MVFilterFrame extends javax.swing.JFrame implements MVFilter {
 
-    Daten daten;
+    private static final long serialVersionUID = 1L;
+
+    private Daten daten;
     static Point mouseDownCompCoords;
-    JFrame parent;
+    private JFrame parent;
     private int aktFilter = -1;
 
     public MVFilterFrame(Daten d) {
@@ -56,7 +58,8 @@ public class MVFilterFrame extends javax.swing.JFrame implements MVFilter {
             im.put(KeyStroke.getKeyStroke(KeyEvent.VK_F4, 0), "einstellungen");
             ActionMap am = jComboBoxFilterSender.getActionMap();
             am.put("einstellungen", new AbstractAction() {
-
+                private static final long serialVersionUID = 1L;
+                
                 @Override
                 public void actionPerformed(ActionEvent e) {
                     Daten.dialogEinstellungen.setVisible(true);
@@ -66,7 +69,8 @@ public class MVFilterFrame extends javax.swing.JFrame implements MVFilter {
             im.put(KeyStroke.getKeyStroke(KeyEvent.VK_F4, 0), "einstellungen");
             am = jComboBoxFilterThema.getActionMap();
             am.put("einstellungen", new AbstractAction() {
-
+                private static final long serialVersionUID = 1L;
+                
                 @Override
                 public void actionPerformed(ActionEvent e) {
                     Daten.dialogEinstellungen.setVisible(true);

--- a/src/mediathek/gui/MVFilterFrame.java
+++ b/src/mediathek/gui/MVFilterFrame.java
@@ -118,7 +118,7 @@ public class MVFilterFrame extends javax.swing.JFrame implements MVFilter {
         });
         this.setIconImage(GetIcon.getIcon("MediathekView.png", "/mediathek/res/", 58, 58).getImage());
         this.setTitle("Filter");
-        GuiFunktionen.setSize(MVConfig.Configs.SYSTEM_GROESSE_FILTER, this, daten.mediathekGui);
+        GuiFunktionen.setSize(MVConfig.Configs.SYSTEM_GROESSE_FILTER, this, Daten.mediathekGui);
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {

--- a/src/mediathek/gui/MVFilterPanel.java
+++ b/src/mediathek/gui/MVFilterPanel.java
@@ -38,6 +38,8 @@ import mediathek.tool.TextCopyPaste;
 
 public class MVFilterPanel extends javax.swing.JPanel implements MVFilter {
 
+    private static final long serialVersionUID = 1L;
+
     private int aktFilter = -1;
     private final JFrame parent;
     private final Daten daten;
@@ -54,6 +56,7 @@ public class MVFilterPanel extends javax.swing.JPanel implements MVFilter {
             im.put(KeyStroke.getKeyStroke(KeyEvent.VK_F4, 0), "einstellungen");
             ActionMap am = jComboBoxFilterSender.getActionMap();
             am.put("einstellungen", new AbstractAction() {
+                private static final long serialVersionUID = 1L;
 
                 @Override
                 public void actionPerformed(ActionEvent e) {
@@ -64,6 +67,7 @@ public class MVFilterPanel extends javax.swing.JPanel implements MVFilter {
             im.put(KeyStroke.getKeyStroke(KeyEvent.VK_F4, 0), "einstellungen");
             am = jComboBoxFilterThema.getActionMap();
             am.put("einstellungen", new AbstractAction() {
+                private static final long serialVersionUID = 1L;
 
                 @Override
                 public void actionPerformed(ActionEvent e) {

--- a/src/mediathek/gui/MVMemoryUsageButton.java
+++ b/src/mediathek/gui/MVMemoryUsageButton.java
@@ -8,6 +8,8 @@ import static mSearch.tool.Functions.getOs;
 
 public class MVMemoryUsageButton extends JButton {
 
+    private static final long serialVersionUID = 1L;
+
     private final Runtime rt = Runtime.getRuntime();
     private final String MEMORY_STRING;
 

--- a/src/mediathek/gui/MVStatusBar.java
+++ b/src/mediathek/gui/MVStatusBar.java
@@ -25,6 +25,8 @@ import mediathek.daten.DatenDownload;
  */
 public final class MVStatusBar extends JPanel {
 
+    private static final long serialVersionUID = 1L;
+
     private boolean stopTimer = false;
     private final EnumMap<MVStatusBar.StatusbarIndex, String> displayListForLeftLabel = new EnumMap<>(MVStatusBar.StatusbarIndex.class);
     private MVStatusBar.StatusbarIndex currentIndex = MVStatusBar.StatusbarIndex.NONE;

--- a/src/mediathek/gui/MVStatusBar.java
+++ b/src/mediathek/gui/MVStatusBar.java
@@ -237,7 +237,7 @@ public final class MVStatusBar extends JPanel {
     }
 
     private void setInfoDownload() {
-        lblSel.setText(daten.guiDownloads.tabelle.getSelectedRowCount() + "");
+        lblSel.setText(Daten.guiDownloads.tabelle.getSelectedRowCount() + "");
         String textLinks = getInfoTextDownloads(true /*mitAbo*/);
 
         displayListForLeftLabel.put(MVStatusBar.StatusbarIndex.DOWNLOAD, textLinks);

--- a/src/mediathek/gui/MVTray.java
+++ b/src/mediathek/gui/MVTray.java
@@ -106,7 +106,7 @@ public final class MVTray {
             public void mouseClicked(MouseEvent e) {
                 if (e.getButton() == MouseEvent.BUTTON1) {
                     if (e.getClickCount() == 1) {
-                        Daten.mediathekGui.setVisible(!daten.mediathekGui.isVisible());
+                        Daten.mediathekGui.setVisible(!Daten.mediathekGui.isVisible());
                         if (Daten.mediathekGui.isVisible()) {
                             Daten.mediathekGui.toFront();
                             Daten.mediathekGui.requestFocus();

--- a/src/mediathek/gui/PanelFilmBeschreibung.java
+++ b/src/mediathek/gui/PanelFilmBeschreibung.java
@@ -43,6 +43,8 @@ import mediathek.tool.UrlHyperlinkAction;
  */
 public class PanelFilmBeschreibung extends JPanel implements ListSelectionListener {
 
+    private static final long serialVersionUID = 1L;
+    
     private DatenFilm currentFilm = null;
     private MVTable table = null;
 

--- a/src/mediathek/gui/PanelInfoStarts.java
+++ b/src/mediathek/gui/PanelInfoStarts.java
@@ -29,6 +29,8 @@ import mSearch.daten.DatenFilm;
 
 public class PanelInfoStarts extends JPanel {
 
+    private static final long serialVersionUID = 1L;
+    
     private TModel tModel;
 
     public PanelInfoStarts() {

--- a/src/mediathek/gui/PanelVorlage.java
+++ b/src/mediathek/gui/PanelVorlage.java
@@ -25,6 +25,8 @@ import mediathek.tool.MVTable;
 
 public class PanelVorlage extends javax.swing.JPanel {
 
+    private static final long serialVersionUID = 1L;
+    
     public Daten daten;
     public boolean stopBeob = false;
     public JFrame parentComponent = null;

--- a/src/mediathek/gui/ToolBar.java
+++ b/src/mediathek/gui/ToolBar.java
@@ -36,6 +36,8 @@ import org.jdesktop.swingx.JXSearchField;
 
 public final class ToolBar extends JToolBar {
 
+    private static final long serialVersionUID = 1L;
+
     Filler filler__5 = new Filler(new java.awt.Dimension(5, 20), new java.awt.Dimension(5, 20), new java.awt.Dimension(5, 32767));
     Filler filler__10 = new Filler(new java.awt.Dimension(10, 20), new java.awt.Dimension(10, 20), new java.awt.Dimension(10, 32767));
     Filler filler__trenner = new javax.swing.Box.Filler(new java.awt.Dimension(1, 5), new java.awt.Dimension(1, 5), new java.awt.Dimension(32767, 5));
@@ -378,10 +380,12 @@ public final class ToolBar extends JToolBar {
 
     private class MVButton extends JButton {
 
+        private static final long serialVersionUID = 1L;
+        
         boolean anzeigen = true;
-        String name = "";
-        ImageIcon imageIconKlein;
-        ImageIcon imageIconNormal;
+        private String name = "";
+        private ImageIcon imageIconKlein;
+        private ImageIcon imageIconNormal;
 
         public MVButton(String nname, String ttoolTip,
                 ImageIcon iimageIconNormal, ImageIcon iimageIconKlein) {

--- a/src/mediathek/gui/dialog/DialogAboNoSet.java
+++ b/src/mediathek/gui/dialog/DialogAboNoSet.java
@@ -29,6 +29,8 @@ import mediathek.tool.GuiFunktionenProgramme;
 
 public class DialogAboNoSet extends javax.swing.JDialog {
 
+    private static final long serialVersionUID = 1L;
+    
     /**
      *
      * @param parent

--- a/src/mediathek/gui/dialog/DialogAddDownload.java
+++ b/src/mediathek/gui/dialog/DialogAddDownload.java
@@ -49,7 +49,9 @@ import mediathek.tool.MVFilmSize;
 import mediathek.tool.MVMessageDialog;
 
 public class DialogAddDownload extends JDialog {
-
+    
+    private static final long serialVersionUID = 1L;
+    
     private DatenPset pSet = null;
     private boolean ok = false;
     private DatenDownload datenDownload = null;

--- a/src/mediathek/gui/dialog/DialogAddMoreDownload.java
+++ b/src/mediathek/gui/dialog/DialogAddMoreDownload.java
@@ -41,6 +41,8 @@ import mediathek.tool.EscBeenden;
 
 public class DialogAddMoreDownload extends javax.swing.JDialog {
 
+    private static final long serialVersionUID = 1L;
+    
     public boolean addAll = false;
     public boolean cancel = false;
     public boolean info;

--- a/src/mediathek/gui/dialog/DialogBeenden.java
+++ b/src/mediathek/gui/dialog/DialogBeenden.java
@@ -32,6 +32,8 @@ import org.jdesktop.swingx.JXBusyLabel;
 
 public class DialogBeenden extends JDialog {
 
+    private static final long serialVersionUID = 1L;
+    
     private static final String CANCEL_AND_TERMINATE_PROGRAM = "Downloads abbrechen und Programm beenden";
     private static final String WAIT_FOR_DOWNLOADS_AND_TERMINATE = "Auf Abschluß aller Downloads warten, danach beenden";
     private static final String WAIT_FOR_RUNNING_DOWNLOADS_AND_TERMINATE = "Nur auf bereits laufende Downloads warten, danach beenden";

--- a/src/mediathek/gui/dialog/DialogBeendenZeit.java
+++ b/src/mediathek/gui/dialog/DialogBeendenZeit.java
@@ -38,6 +38,8 @@ import org.jdesktop.swingx.JXBusyLabel;
 
 public class DialogBeendenZeit extends JDialog {
     
+    private static final long serialVersionUID = 1L;
+    
     private static final String WAIT_FOR_DOWNLOADS_AND_TERMINATE = "Auf Abschluß aller Downloads warten und danach Programm beenden";
     private static final String WAIT_FOR_DOWNLOADS_AND_DONT_TERMINATE_PROGRAM = "Auf Abschluß aller Downloads warten, Programm danach NICHT beenden";
     private static final String DONT_START = "Downloads nicht starten";

--- a/src/mediathek/gui/dialog/DialogContinueDownload.java
+++ b/src/mediathek/gui/dialog/DialogContinueDownload.java
@@ -35,6 +35,8 @@ import mediathek.tool.MVMessageDialog;
 
 public class DialogContinueDownload extends JDialog {
 
+    private static final long serialVersionUID = 1L;
+    
     public enum DownloadResult {
 
         CANCELLED, CONTINUE, RESTART_WITH_NEW_NAME

--- a/src/mediathek/gui/dialog/DialogEditAbo.java
+++ b/src/mediathek/gui/dialog/DialogEditAbo.java
@@ -39,6 +39,8 @@ import mediathek.tool.MVMessageDialog;
 
 public class DialogEditAbo extends javax.swing.JDialog {
 
+    private static final long serialVersionUID = 1L;
+    
     private final DatenAbo aktAbo;
     private JTextField[] textfeldListe;
     private final JComboBox<String> comboboxPSet = new JComboBox<>();

--- a/src/mediathek/gui/dialog/DialogEditDownload.java
+++ b/src/mediathek/gui/dialog/DialogEditDownload.java
@@ -42,6 +42,8 @@ import mediathek.tool.MVMessageDialog;
 
 public class DialogEditDownload extends javax.swing.JDialog {
 
+    private static final long serialVersionUID = 1L;
+    
     private final DatenDownload datenDownload;
     public boolean ok = false;
     private final JTextField[] textfeldListe = new JTextField[DatenDownload.MAX_ELEM];

--- a/src/mediathek/gui/dialog/DialogFilmBeschreibung.java
+++ b/src/mediathek/gui/dialog/DialogFilmBeschreibung.java
@@ -28,6 +28,8 @@ import mediathek.config.Icons;
 
 public class DialogFilmBeschreibung extends javax.swing.JDialog {
 
+    private static final long serialVersionUID = 1L;
+    
     DatenFilm datenFilm;
     JFrame paFrame;
     Daten daten;

--- a/src/mediathek/gui/dialog/DialogHilfe.java
+++ b/src/mediathek/gui/dialog/DialogHilfe.java
@@ -25,6 +25,8 @@ import mediathek.tool.EscBeenden;
 
 public class DialogHilfe extends javax.swing.JDialog {
 
+    private static final long serialVersionUID = 1L;
+    
     public DialogHilfe(JFrame parent, boolean modal, String text) {
         super(parent, modal);
         initComponents();

--- a/src/mediathek/gui/dialog/DialogHinweisUpdate.java
+++ b/src/mediathek/gui/dialog/DialogHinweisUpdate.java
@@ -28,6 +28,8 @@ import mediathek.tool.UrlHyperlinkAction;
 
 public class DialogHinweisUpdate extends javax.swing.JDialog {
 
+    private static final long serialVersionUID = 1L;
+    
     private String text = "";
     private final JFrame parent;
 

--- a/src/mediathek/gui/dialog/DialogLeer.java
+++ b/src/mediathek/gui/dialog/DialogLeer.java
@@ -25,6 +25,8 @@ import mediathek.tool.EscBeenden;
 
 public class DialogLeer extends javax.swing.JDialog {
 
+    private static final long serialVersionUID = 1L;
+    
     public DialogLeer(java.awt.Frame parent, boolean modal) {
         super(parent, modal);
         initComponents();

--- a/src/mediathek/gui/dialog/DialogMediaDB.java
+++ b/src/mediathek/gui/dialog/DialogMediaDB.java
@@ -46,6 +46,8 @@ import mediathek.tool.*;
 
 public class DialogMediaDB extends javax.swing.JDialog {
 
+    private static final long serialVersionUID = 1L;
+    
     private final JFrame parent;
 //    private boolean init = false;
     private MVTable tabelleFilme;

--- a/src/mediathek/gui/dialog/DialogNewSet.java
+++ b/src/mediathek/gui/dialog/DialogNewSet.java
@@ -33,6 +33,8 @@ import mediathek.tool.UrlHyperlinkAction;
 
 public class DialogNewSet extends javax.swing.JDialog {
 
+    private static final long serialVersionUID = 1L;
+    
     public boolean ok = false;
     public boolean morgen = true;
     private JFrame parent;

--- a/src/mediathek/gui/dialog/DialogOk.java
+++ b/src/mediathek/gui/dialog/DialogOk.java
@@ -27,6 +27,8 @@ import mediathek.tool.EscBeenden;
 
 public class DialogOk extends javax.swing.JDialog {
 
+    private static final long serialVersionUID = 1L;
+    
     /**
      *
      * @param parent

--- a/src/mediathek/gui/dialog/DialogProgrammOrdnerOeffnen.java
+++ b/src/mediathek/gui/dialog/DialogProgrammOrdnerOeffnen.java
@@ -35,6 +35,8 @@ import mediathek.tool.MVMessageDialog;
 
 public class DialogProgrammOrdnerOeffnen extends javax.swing.JDialog {
 
+    private static final long serialVersionUID = 1L;
+    
     public boolean ok = false;
     public String ziel;
     private Frame parentComponent = null;

--- a/src/mediathek/gui/dialog/DialogStarteinstellungen.java
+++ b/src/mediathek/gui/dialog/DialogStarteinstellungen.java
@@ -37,14 +37,16 @@ import mediathek.tool.GuiFunktionenProgramme;
 
 public class DialogStarteinstellungen extends javax.swing.JDialog {
 
-    Daten daten;
+    private static final long serialVersionUID = 1L;
+    
+    private Daten daten;
     private final static int STAT_START = 1;
     private final static int STAT_PFAD = 2;
     private final static int STAT_PSET = 3;
     private final static int STAT_FERTIG = 4;
     private int status = STAT_START;
     private final JFrame parentComponent;
-    JCheckBox jCheckBox = new JCheckBox("Einmal am Tag nach einer neuen Programmversion suchen");
+    private JCheckBox jCheckBox = new JCheckBox("Einmal am Tag nach einer neuen Programmversion suchen");
     private boolean anpassen = false;
 
     public DialogStarteinstellungen(JFrame parent, Daten dd) {

--- a/src/mediathek/gui/dialog/DialogZiel.java
+++ b/src/mediathek/gui/dialog/DialogZiel.java
@@ -34,6 +34,8 @@ import mediathek.tool.GuiFunktionen;
 
 public class DialogZiel extends javax.swing.JDialog {
 
+    private static final long serialVersionUID = 1L;
+    
     public boolean ok = false;
     public String ziel;
 //    private Component parentComponent = null;

--- a/src/mediathek/gui/dialog/MVPanelDownloadZiel.java
+++ b/src/mediathek/gui/dialog/MVPanelDownloadZiel.java
@@ -46,6 +46,8 @@ import mediathek.tool.MVMessageDialog;
 
 public class MVPanelDownloadZiel extends javax.swing.JPanel {
 
+    private static final long serialVersionUID = 1L;
+    
     public boolean nameGeaendert = false;
     private DatenDownload datenDownload;
     private JFrame parent = null;

--- a/src/mediathek/gui/dialog/MeldungDownloadfehler.java
+++ b/src/mediathek/gui/dialog/MeldungDownloadfehler.java
@@ -29,6 +29,8 @@ import mediathek.tool.EscBeenden;
 
 public class MeldungDownloadfehler extends javax.swing.JDialog {
 
+    private static final long serialVersionUID = 1L;
+    
     private Timer countdownTimer = null;
 
     /**

--- a/src/mediathek/gui/dialogEinstellungen/DialogEinstellungen.java
+++ b/src/mediathek/gui/dialogEinstellungen/DialogEinstellungen.java
@@ -34,7 +34,9 @@ import mediathek.tool.GuiFunktionen;
 
 public class DialogEinstellungen extends javax.swing.JFrame {
 
-    Daten ddaten;
+    private static final long serialVersionUID = 1L;
+
+    private Daten ddaten;
     public boolean ok = false;
     private PanelEinstellungen panelEinstellungen;
     private PanelDownload panelDownload;

--- a/src/mediathek/gui/dialogEinstellungen/DialogFarbe.java
+++ b/src/mediathek/gui/dialogEinstellungen/DialogFarbe.java
@@ -29,6 +29,8 @@ import mediathek.tool.EscBeenden;
 
 public class DialogFarbe extends javax.swing.JDialog {
 
+    private static final long serialVersionUID = 1L;
+
     public Color farbe = null;
 
     public DialogFarbe(JFrame parent, boolean modal, Color color) {

--- a/src/mediathek/gui/dialogEinstellungen/DialogImportPset.java
+++ b/src/mediathek/gui/dialogEinstellungen/DialogImportPset.java
@@ -26,6 +26,8 @@ import mediathek.tool.EscBeenden;
 
 public class DialogImportPset extends javax.swing.JDialog {
 
+    private static final long serialVersionUID = 1L;
+
     public boolean ok = false;
     private ListePset liste;
     private Daten ddaten;

--- a/src/mediathek/gui/dialogEinstellungen/DialogZielExportPset.java
+++ b/src/mediathek/gui/dialogEinstellungen/DialogZielExportPset.java
@@ -183,7 +183,7 @@ public class DialogZielExportPset extends javax.swing.JDialog {
         public void actionPerformed(ActionEvent e) {
             //we can use native chooser on Mac...
             if (SystemInfo.isMacOSX()) {
-                FileDialog chooser = new FileDialog(ddaten.mediathekGui, "Logdatei speichern");
+                FileDialog chooser = new FileDialog(Daten.mediathekGui, "Logdatei speichern");
                 chooser.setMode(FileDialog.SAVE);
                 chooser.setVisible(true);
                 if (chooser.getFile() != null) {

--- a/src/mediathek/gui/dialogEinstellungen/DialogZielExportPset.java
+++ b/src/mediathek/gui/dialogEinstellungen/DialogZielExportPset.java
@@ -37,6 +37,8 @@ import mediathek.tool.MVMessageDialog;
 
 public class DialogZielExportPset extends javax.swing.JDialog {
 
+    private static final long serialVersionUID = 1L;
+
     public boolean ok = false;
     public String ziel = "";
     private Component parentComponent = null;

--- a/src/mediathek/gui/dialogEinstellungen/PanelBlacklist.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelBlacklist.java
@@ -50,6 +50,8 @@ import mediathek.tool.TextCopyPaste;
 
 public class PanelBlacklist extends PanelVorlage {
 
+    private static final long serialVersionUID = 1L;
+    
     public boolean ok = false;
     public String ziel;
     private final String name;

--- a/src/mediathek/gui/dialogEinstellungen/PanelDateinamen.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelDateinamen.java
@@ -39,6 +39,8 @@ import mediathek.tool.TextCopyPaste;
 
 public class PanelDateinamen extends PanelVorlage {
 
+    private static final long serialVersionUID = 1L;
+    
     public boolean ok = false;
     public String ziel = "";
     private final Color cGruen = new Color(0, 153, 51);

--- a/src/mediathek/gui/dialogEinstellungen/PanelDownload.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelDownload.java
@@ -33,6 +33,8 @@ import mediathek.gui.dialog.DialogHilfe;
 
 public class PanelDownload extends PanelVorlage {
 
+    private static final long serialVersionUID = 1L;
+    
     public PanelDownload(Daten d, JFrame parent) {
         super(d, parent);
         initComponents();

--- a/src/mediathek/gui/dialogEinstellungen/PanelEinstellungen.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelEinstellungen.java
@@ -42,6 +42,8 @@ import mediathek.tool.MVMessageDialog;
 
 public class PanelEinstellungen extends PanelVorlage {
 
+    private static final long serialVersionUID = 1L;
+    
     private final static String ICONSET_STANDARD = "Standard";
     private final String ALLE = " Alle ";
 

--- a/src/mediathek/gui/dialogEinstellungen/PanelEinstellungen.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelEinstellungen.java
@@ -166,7 +166,6 @@ public class PanelEinstellungen extends PanelVorlage {
         jSpinnerDays.setValue(s);
     }
 
-    @SuppressWarnings("unchecked")
     private void setupLookAndFeelComboBox() {
         try {
             //query all installed LAFs
@@ -185,7 +184,7 @@ public class PanelEinstellungen extends PanelVorlage {
                     idx = i;
                 }
             }
-            DefaultComboBoxModel<String> model = new DefaultComboBoxModel(themeList.toArray());
+            DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>(themeList.toArray(new String[0]));
             jComboBoxLookAndFeel.setModel(model);
             jComboBoxLookAndFeel.setSelectedIndex(idx);
 

--- a/src/mediathek/gui/dialogEinstellungen/PanelEinstellungenColor.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelEinstellungenColor.java
@@ -35,6 +35,8 @@ import mediathek.tool.TModelColor;
 
 public class PanelEinstellungenColor extends PanelVorlage {
 
+    private static final long serialVersionUID = 1L;
+    
     public PanelEinstellungenColor(Daten d, JFrame pparentComponent) {
         super(d, pparentComponent);
         initComponents();

--- a/src/mediathek/gui/dialogEinstellungen/PanelEinstellungenErweitert.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelEinstellungenErweitert.java
@@ -46,6 +46,8 @@ import mediathek.tool.TextCopyPaste;
 
 public class PanelEinstellungenErweitert extends PanelVorlage {
 
+    private static final long serialVersionUID = 1L;
+    
     public PanelEinstellungenErweitert(Daten d, JFrame pparentComponent) {
         super(d, pparentComponent);
         initComponents();

--- a/src/mediathek/gui/dialogEinstellungen/PanelEinstellungenGeo.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelEinstellungenGeo.java
@@ -33,6 +33,8 @@ import mediathek.gui.dialog.DialogHilfe;
 
 public class PanelEinstellungenGeo extends PanelVorlage {
 
+    private static final long serialVersionUID = 1L;
+    
     public PanelEinstellungenGeo(Daten d, JFrame pparentComponent) {
         super(d, pparentComponent);
         initComponents();

--- a/src/mediathek/gui/dialogEinstellungen/PanelErledigteUrls.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelErledigteUrls.java
@@ -47,6 +47,8 @@ import mediathek.tool.TModel;
 
 public class PanelErledigteUrls extends PanelVorlage {
 
+    private static final long serialVersionUID = 1L;
+    
     private boolean abo;
 
     public PanelErledigteUrls(Daten d, JFrame parentComponent) {

--- a/src/mediathek/gui/dialogEinstellungen/PanelErledigteUrls.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelErledigteUrls.java
@@ -179,7 +179,6 @@ public class PanelErledigteUrls extends PanelVorlage {
                 bw.newLine();
                 //
                 bw.flush();
-                bw.close();
             } catch (Exception ex) {
                 SwingUtilities.invokeLater(new Runnable() {
                     @Override

--- a/src/mediathek/gui/dialogEinstellungen/PanelExportFilmliste.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelExportFilmliste.java
@@ -41,6 +41,8 @@ import mediathek.tool.TextCopyPaste;
 
 public class PanelExportFilmliste extends PanelVorlage {
 
+    private static final long serialVersionUID = 1L;
+    
     public String ziel;
 
     public PanelExportFilmliste(Daten d, JFrame parent) {

--- a/src/mediathek/gui/dialogEinstellungen/PanelFilmlisteLaden.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelFilmlisteLaden.java
@@ -36,7 +36,9 @@ import mediathek.tool.GuiFunktionen;
 import mediathek.tool.TextCopyPaste;
 
 public class PanelFilmlisteLaden extends PanelVorlage {
-
+    
+    private static final long serialVersionUID = 1L;
+    
     public PanelFilmlisteLaden(Daten d, JFrame parentComponent) {
         super(d, parentComponent);
         initComponents();

--- a/src/mediathek/gui/dialogEinstellungen/PanelFilmlisten.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelFilmlisten.java
@@ -42,6 +42,8 @@ import mediathek.tool.TModel;
 
 public class PanelFilmlisten extends PanelVorlage {
 
+    private static final long serialVersionUID = 1L;
+    
     public PanelFilmlisten(Daten d, JFrame parentComponent) {
         super(d, parentComponent);
         initComponents();

--- a/src/mediathek/gui/dialogEinstellungen/PanelImport.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelImport.java
@@ -41,6 +41,8 @@ import mediathek.tool.TextCopyPaste;
 
 public class PanelImport extends PanelVorlage {
 
+    private static final long serialVersionUID = 1L;
+    
     //ListePsetVorlagen listeVorlagen = new ListePsetVorlagen();
     public PanelImport(Daten d, JFrame parentComponent) {
         super(d, parentComponent);

--- a/src/mediathek/gui/dialogEinstellungen/PanelMediaDB.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelMediaDB.java
@@ -45,6 +45,8 @@ import mediathek.tool.*;
 
 public class PanelMediaDB extends PanelVorlage {
     
+    private static final long serialVersionUID = 1L;
+    
     private final TModel modelPath = new TModel(new Object[][]{}, DatenMediaPath.COLUMN_NAMES);
     private final TModelMediaDB modelMediaDB = new TModelMediaDB(new Object[][]{}, DatenMediaDB.COLUMN_NAMES);
     

--- a/src/mediathek/gui/dialogEinstellungen/PanelMeldungen.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelMeldungen.java
@@ -35,6 +35,8 @@ import mediathek.gui.PanelVorlage;
 
 public class PanelMeldungen extends PanelVorlage {
 
+    private static final long serialVersionUID = 1L;
+    
     private final ObservableList<String> text;
     private final int logArt;
     private int firstScroll = 25;

--- a/src/mediathek/gui/dialogEinstellungen/PanelProgrammInfos.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelProgrammInfos.java
@@ -35,6 +35,8 @@ import mediathek.tool.UrlHyperlinkAction;
 
 public class PanelProgrammInfos extends PanelVorlage {
 
+    private static final long serialVersionUID = 1L;
+    
     public PanelProgrammInfos(Daten dd, JFrame parentComponent) {
         super(dd, parentComponent);
         initComponents();

--- a/src/mediathek/gui/dialogEinstellungen/PanelProgrammPfade.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelProgrammPfade.java
@@ -41,6 +41,8 @@ import mediathek.tool.UrlHyperlinkAction;
 
 public class PanelProgrammPfade extends JPanel {
 
+    private static final long serialVersionUID = 1L;
+    
     public JDialog dialog = null;
     private final boolean vlc, flvstreamer, ffmpeg;
     private final JFrame parentComponent;

--- a/src/mediathek/gui/dialogEinstellungen/PanelPset.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelPset.java
@@ -29,6 +29,8 @@ import mediathek.gui.PanelVorlage;
 
 public class PanelPset extends PanelVorlage {
 
+    private static final long serialVersionUID = 1L;
+    
     public PanelPset(Daten d, JFrame parentComponent) {
         super(d, parentComponent);
         initComponents();

--- a/src/mediathek/gui/dialogEinstellungen/PanelPsetImport.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelPsetImport.java
@@ -44,7 +44,9 @@ import mediathek.tool.*;
 
 public class PanelPsetImport extends PanelVorlage {
 
-    ListePsetVorlagen listePsetVorlagen = new ListePsetVorlagen();
+    private static final long serialVersionUID = 1L;
+    
+    private ListePsetVorlagen listePsetVorlagen = new ListePsetVorlagen();
 
     public PanelPsetImport(Daten d, JFrame parentComponent) {
         super(d, parentComponent);

--- a/src/mediathek/gui/dialogEinstellungen/PanelPsetKurz.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelPsetKurz.java
@@ -42,6 +42,8 @@ import mediathek.tool.TextCopyPaste;
 
 public class PanelPsetKurz extends PanelVorlage {
 
+    private static final long serialVersionUID = 1L;
+    
     public boolean ok = false;
     public String zielPfad = "";
     private DatenPset pSet = null;

--- a/src/mediathek/gui/dialogEinstellungen/PanelPsetLang.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelPsetLang.java
@@ -48,6 +48,8 @@ import mediathek.tool.*;
 
 public class PanelPsetLang extends PanelVorlage {
 
+    private static final long serialVersionUID = 1L;
+    
     private int neuZaehler = 0;
     private String exportPfad = "";
     private ListePset listePset;

--- a/src/mediathek/mac/MediathekGuiMac.java
+++ b/src/mediathek/mac/MediathekGuiMac.java
@@ -19,6 +19,8 @@ import mediathek.gui.AboutDialog;
 
 public class MediathekGuiMac extends MediathekGui {
 
+    private static final long serialVersionUID = 1L;
+    
     /**
      * Repaint-Thread for progress indicator on OS X.
      */

--- a/src/mediathek/tool/CellRendererAbo.java
+++ b/src/mediathek/tool/CellRendererAbo.java
@@ -35,6 +35,8 @@ import mediathek.daten.DatenAbo;
 
 public class CellRendererAbo extends DefaultTableCellRenderer {
 
+    private static final long serialVersionUID = 1L;
+    
     private final MVSenderIconCache senderIconCache;
     private static ImageIcon ja_16 = null;
     private static ImageIcon nein_12 = null;

--- a/src/mediathek/tool/CellRendererColor.java
+++ b/src/mediathek/tool/CellRendererColor.java
@@ -29,6 +29,8 @@ import mediathek.config.Daten;
 
 public class CellRendererColor extends DefaultTableCellRenderer {
 
+    private static final long serialVersionUID = 1L;
+    
     @Override
     public Component getTableCellRendererComponent(
             JTable table,

--- a/src/mediathek/tool/CellRendererDownloads.java
+++ b/src/mediathek/tool/CellRendererDownloads.java
@@ -38,6 +38,8 @@ import mediathek.daten.DatenDownload;
 
 public class CellRendererDownloads extends DefaultTableCellRenderer {
 
+    private static final long serialVersionUID = 1L;
+    
     private final static String DOWNLOAD_STARTEN = "Download starten";
     private final static String DOWNLOAD_LOESCHEN = "Download aus Liste entfernen";
     private final static String DOWNLOAD_STOPPEN = "Download stoppen";

--- a/src/mediathek/tool/CellRendererFilme.java
+++ b/src/mediathek/tool/CellRendererFilme.java
@@ -41,6 +41,8 @@ import mediathek.daten.DatenDownload;
 
 public class CellRendererFilme extends DefaultTableCellRenderer {
 
+    private static final long serialVersionUID = 1L;
+    
     private static ImageIcon film_start_tab = null;
     private static ImageIcon film_start_sw_tab = null;
     private static ImageIcon film_rec_tab = null;

--- a/src/mediathek/tool/CellRendererMediaDB.java
+++ b/src/mediathek/tool/CellRendererMediaDB.java
@@ -30,6 +30,8 @@ import mediathek.daten.DatenMediaDB;
 
 public class CellRendererMediaDB extends DefaultTableCellRenderer {
 
+    private static final long serialVersionUID = 1L;
+    
     private static ImageIcon ja_16 = null;
     private static ImageIcon nein_12 = null;
 

--- a/src/mediathek/tool/CellRendererProgramme.java
+++ b/src/mediathek/tool/CellRendererProgramme.java
@@ -30,7 +30,9 @@ import mediathek.daten.DatenProg;
 
 public class CellRendererProgramme extends DefaultTableCellRenderer {
 
-    Daten daten;
+    private static final long serialVersionUID = 1L;
+    
+    private Daten daten;
     private static ImageIcon ja_16 = null;
     private static ImageIcon nein_12 = null;
 

--- a/src/mediathek/tool/CellRendererPset.java
+++ b/src/mediathek/tool/CellRendererPset.java
@@ -31,7 +31,9 @@ import mediathek.daten.DatenPset;
 
 public class CellRendererPset extends DefaultTableCellRenderer {
 
-    Daten daten;
+    private static final long serialVersionUID = 1L;
+    
+    private Daten daten;
     private static ImageIcon ja_16 = null;
     private static ImageIcon nein_12 = null;
 

--- a/src/mediathek/tool/EscBeenden.java
+++ b/src/mediathek/tool/EscBeenden.java
@@ -34,6 +34,8 @@ public class EscBeenden {
         // ESC zum Beenden
         frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), "x");
         frame.getRootPane().getActionMap().put("x", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 beenden_();
@@ -43,6 +45,8 @@ public class EscBeenden {
         // für den Mac
         frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_W, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "mac-cancel");
         frame.getRootPane().getActionMap().put("mac-cancel", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 beenden_();
@@ -56,6 +60,8 @@ public class EscBeenden {
         // ESC zum Beenden
         dialog.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), "x");
         dialog.getRootPane().getActionMap().put("x", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 beenden_();
@@ -65,6 +71,8 @@ public class EscBeenden {
         // für den Mac
         dialog.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_W, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "mac-cancel");
         dialog.getRootPane().getActionMap().put("mac-cancel", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 beenden_();

--- a/src/mediathek/tool/GuiFunktionenProgramme.java
+++ b/src/mediathek/tool/GuiFunktionenProgramme.java
@@ -323,7 +323,7 @@ public class GuiFunktionenProgramme extends GuiFunktionen {
         }
 
         ZipFile zipFile = new ZipFile(archive);
-        Enumeration entries = zipFile.entries();
+        Enumeration<? extends ZipEntry> entries = zipFile.entries();
 
         byte[] buffer = new byte[16384];
         int len;

--- a/src/mediathek/tool/Logfile.java
+++ b/src/mediathek/tool/Logfile.java
@@ -190,7 +190,6 @@ public class Logfile {
             bw.newLine();
             bw.newLine();
             //
-            bw.close();
             ret = true;
         } catch (Exception ex) {
             Log.errorLog(319865493, ex);

--- a/src/mediathek/tool/MVFrame.java
+++ b/src/mediathek/tool/MVFrame.java
@@ -32,6 +32,8 @@ import mediathek.res.GetIcon;
 
 public class MVFrame extends javax.swing.JFrame {
 
+    private static final long serialVersionUID = 1L;
+    
     private final Daten daten;
     private final MediathekGui.TABS state;
     private Configs nrGroesse = null;

--- a/src/mediathek/tool/MVRun.java
+++ b/src/mediathek/tool/MVRun.java
@@ -24,6 +24,8 @@ import javax.swing.SwingUtilities;
 
 public class MVRun extends javax.swing.JDialog {
 
+    private static final long serialVersionUID = 1L;
+    
     /**
      *
      * @param parent

--- a/src/mediathek/tool/MVTable.java
+++ b/src/mediathek/tool/MVTable.java
@@ -46,6 +46,8 @@ import mediathek.daten.*;
 
 public final class MVTable extends JTable {
 
+    private static final long serialVersionUID = 1L;
+    
     public enum TableType {
         STANDARD, FILME, DOWNLOADS, ABOS, PSET, PROG, MEDIA_DB
     };
@@ -861,8 +863,10 @@ public final class MVTable extends JTable {
         return ++ret;
     }
 
-    class TableRowTransferHandlerDownload extends TransferHandler {
+    private class TableRowTransferHandlerDownload extends TransferHandler {
 
+        private static final long serialVersionUID = 1L;
+        
         //private final DataFlavor localObjectFlavor = new ActivationDataFlavor(Integer.class, DataFlavor.javaJVMLocalObjectMimeType, "Integer Row Index");
         private final DataFlavor localObjectFlavor = new DataFlavor(Integer.class, "Integer Row Index");
         private JTable table = null;

--- a/src/mediathek/tool/MVTable.java
+++ b/src/mediathek/tool/MVTable.java
@@ -188,6 +188,7 @@ public final class MVTable extends JTable {
         mdl.setValueIsAdjusting(false);
     }
 
+    @SuppressWarnings("fallthrough")
     public void setHeight() {
         int sizeArea = 0;
         int size;

--- a/src/mediathek/tool/TModel.java
+++ b/src/mediathek/tool/TModel.java
@@ -44,7 +44,7 @@ public class TModel extends DefaultTableModel {
         // die Indexspalte ist die SPALTE 0!!!!
         int ret = 0;
         for (List<Integer> list : (Iterable<List<Integer>>) getDataVector()) {
-            if ((Integer) list.get(0) == idxWert) {
+            if (list.get(0) == idxWert) {
                 return ret;
             }
             ++ret;

--- a/src/mediathek/tool/TModel.java
+++ b/src/mediathek/tool/TModel.java
@@ -43,7 +43,7 @@ public class TModel extends DefaultTableModel {
         // liefert die Zeile in der die erste Spalte idx enthält
         // die Indexspalte ist die SPALTE 0!!!!
         int ret = 0;
-        for (List list : (Iterable<List>) getDataVector()) {
+        for (List<Integer> list : (Iterable<List<Integer>>) getDataVector()) {
             if ((Integer) list.get(0) == idxWert) {
                 return ret;
             }

--- a/src/mediathek/tool/TModel.java
+++ b/src/mediathek/tool/TModel.java
@@ -24,6 +24,8 @@ import javax.swing.table.DefaultTableModel;
 
 public class TModel extends DefaultTableModel {
 
+    private static final long serialVersionUID = 1L;
+    
     public TModel() {
     }
 

--- a/src/mediathek/tool/TModelAbo.java
+++ b/src/mediathek/tool/TModelAbo.java
@@ -24,7 +24,9 @@ import mSearch.tool.Datum;
 
 public class TModelAbo extends TModel {
 
-    Class[] types;
+    private static final long serialVersionUID = 1L;
+    
+    private Class[] types;
 
     public TModelAbo(Object[][] data, Object[] columnNames) {
         super(data, columnNames);

--- a/src/mediathek/tool/TModelAbo.java
+++ b/src/mediathek/tool/TModelAbo.java
@@ -26,7 +26,7 @@ public class TModelAbo extends TModel {
 
     private static final long serialVersionUID = 1L;
     
-    private Class[] types;
+    private Class<?>[] types;
 
     public TModelAbo(Object[][] data, Object[] columnNames) {
         super(data, columnNames);

--- a/src/mediathek/tool/TModelColor.java
+++ b/src/mediathek/tool/TModelColor.java
@@ -23,7 +23,9 @@ import mediathek.config.MVColor;
 
 public class TModelColor extends TModel {
 
-    Class[] types;
+    private static final long serialVersionUID = 1L;
+    
+    private Class[] types;
 
     public TModelColor(Object[][] data, Object[] columnNames) {
         super(data, columnNames);

--- a/src/mediathek/tool/TModelColor.java
+++ b/src/mediathek/tool/TModelColor.java
@@ -25,7 +25,7 @@ public class TModelColor extends TModel {
 
     private static final long serialVersionUID = 1L;
     
-    private Class[] types;
+    private Class<?>[] types;
 
     public TModelColor(Object[][] data, Object[] columnNames) {
         super(data, columnNames);

--- a/src/mediathek/tool/TModelDownload.java
+++ b/src/mediathek/tool/TModelDownload.java
@@ -23,6 +23,7 @@ import mSearch.tool.Datum;
 import mediathek.daten.DatenDownload;
 
 public class TModelDownload extends TModel {
+    private static final long serialVersionUID = 1L;
 
     private Class[] types;
 

--- a/src/mediathek/tool/TModelDownload.java
+++ b/src/mediathek/tool/TModelDownload.java
@@ -25,7 +25,7 @@ import mediathek.daten.DatenDownload;
 public class TModelDownload extends TModel {
     private static final long serialVersionUID = 1L;
 
-    private Class[] types;
+    private Class<?>[] types;
 
     public TModelDownload(Object[][] data, Object[] columnNames) {
         super(data, columnNames);

--- a/src/mediathek/tool/TModelFilm.java
+++ b/src/mediathek/tool/TModelFilm.java
@@ -24,7 +24,9 @@ import mSearch.tool.Datum;
 
 public class TModelFilm extends TModel {
 
-    Class[] types;
+    private static final long serialVersionUID = 1L;
+    
+    private Class[] types;
 
     public TModelFilm(Object[][] data, Object[] columnNames) {
         super(data, columnNames);

--- a/src/mediathek/tool/TModelFilm.java
+++ b/src/mediathek/tool/TModelFilm.java
@@ -26,7 +26,7 @@ public class TModelFilm extends TModel {
 
     private static final long serialVersionUID = 1L;
     
-    private Class[] types;
+    private Class<?>[] types;
 
     public TModelFilm(Object[][] data, Object[] columnNames) {
         super(data, columnNames);

--- a/src/mediathek/tool/TModelMediaDB.java
+++ b/src/mediathek/tool/TModelMediaDB.java
@@ -23,7 +23,9 @@ import mediathek.daten.DatenMediaDB;
 
 public class TModelMediaDB extends TModel {
 
-    Class[] types;
+    private static final long serialVersionUID = 1L;
+    
+    private Class[] types;
 
     public TModelMediaDB(Object[][] data, Object[] columnNames) {
         super(data, columnNames);

--- a/src/mediathek/tool/TModelMediaDB.java
+++ b/src/mediathek/tool/TModelMediaDB.java
@@ -25,7 +25,7 @@ public class TModelMediaDB extends TModel {
 
     private static final long serialVersionUID = 1L;
     
-    private Class[] types;
+    private Class<?>[] types;
 
     public TModelMediaDB(Object[][] data, Object[] columnNames) {
         super(data, columnNames);

--- a/src/mediathek/tool/TextCopyPaste.java
+++ b/src/mediathek/tool/TextCopyPaste.java
@@ -50,7 +50,8 @@ public class TextCopyPaste extends MouseAdapter {
 
     public TextCopyPaste() {
         undoAction = new AbstractAction("Zurück") {
-
+            private static final long serialVersionUID = 1L;
+            
             @Override
             public void actionPerformed(ActionEvent ae) {
                 textComponent.setText("");
@@ -64,7 +65,8 @@ public class TextCopyPaste extends MouseAdapter {
         popup.addSeparator();
 
         cutAction = new AbstractAction("Ausschneiden") {
-
+            private static final long serialVersionUID = 1L;
+            
             @Override
             public void actionPerformed(ActionEvent ae) {
                 lastActionSelected = Actions.CUT;
@@ -76,7 +78,8 @@ public class TextCopyPaste extends MouseAdapter {
         popup.add(cutAction);
 
         copyAction = new AbstractAction("Kopieren") {
-
+            private static final long serialVersionUID = 1L;
+            
             @Override
             public void actionPerformed(ActionEvent ae) {
                 lastActionSelected = Actions.COPY;
@@ -87,7 +90,8 @@ public class TextCopyPaste extends MouseAdapter {
         popup.add(copyAction);
 
         pasteAction = new AbstractAction("Einfügen") {
-
+            private static final long serialVersionUID = 1L;
+            
             @Override
             public void actionPerformed(ActionEvent ae) {
                 lastActionSelected = Actions.PASTE;
@@ -100,7 +104,8 @@ public class TextCopyPaste extends MouseAdapter {
         popup.addSeparator();
 
         selectAllAction = new AbstractAction("Alles markieren") {
-
+            private static final long serialVersionUID = 1L;
+            
             @Override
             public void actionPerformed(ActionEvent ae) {
                 lastActionSelected = Actions.SELECT_ALL;

--- a/src/mediathek/tool/UrlHyperlinkAction.java
+++ b/src/mediathek/tool/UrlHyperlinkAction.java
@@ -33,8 +33,10 @@ import mediathek.gui.dialog.DialogProgrammOrdnerOeffnen;
 
 public class UrlHyperlinkAction extends AbstractAction {
 
-    String url;
-    JFrame jFrameParent;
+    private static final long serialVersionUID = 1L;
+    
+    private String url;
+    private JFrame jFrameParent;
 
     public UrlHyperlinkAction(JFrame jjFrameParent, String uurl) throws URISyntaxException {
         url = uurl;

--- a/src/net/sf/jtelegraph/TelegraphQueue.java
+++ b/src/net/sf/jtelegraph/TelegraphQueue.java
@@ -80,11 +80,10 @@ import javax.swing.Timer;
  * @version 1.0
  * @since 1.0
  */
-@SuppressWarnings("unchecked")
 public class TelegraphQueue implements ActionListener {
 
     // a queue, a timer and a notification
-    private Queue queue;
+    private Queue<Telegraph> queue;
     private Timer timer;
     private Telegraph current;
 
@@ -93,7 +92,7 @@ public class TelegraphQueue implements ActionListener {
      * the local attributes.
      */
     public TelegraphQueue() {
-        queue = new LinkedList();
+        queue = new LinkedList<>();
         timer = new Timer(50, this);
         current = null;
     }

--- a/src/net/sf/jtelegraph/TelegraphQueue.java
+++ b/src/net/sf/jtelegraph/TelegraphQueue.java
@@ -147,7 +147,7 @@ public class TelegraphQueue implements ActionListener {
             if ((!queue.isEmpty()) && (!current.isRunning())) {
 
                 // poll a notification from the queue
-                current = (Telegraph) queue.poll();
+                current = queue.poll();
 
                 // animate
                 current.animate();

--- a/src/org/jdesktop/animation/timing/interpolation/Evaluator.java
+++ b/src/org/jdesktop/animation/timing/interpolation/Evaluator.java
@@ -75,7 +75,7 @@ public abstract class Evaluator<T> {
     /**
      * HashMap that holds all registered evaluators
      */
-    private static final Map<Class<?>, Class<? extends Evaluator>> 
+    private static final Map<Class<?>, Class<? extends Evaluator<?>>> 
             impls = new HashMap<>();
     
     /**
@@ -101,7 +101,7 @@ public abstract class Evaluator<T> {
     }
 
     private static void register(Class<?> type,
-                                Class<? extends Evaluator> impl)
+                                Class<? extends Evaluator<?>> impl)
     {
         impls.put(type, impl);
     }
@@ -112,7 +112,7 @@ public abstract class Evaluator<T> {
 
     @SuppressWarnings("unchecked")
     static <T> Evaluator<T> create(Class<?> type) {
-        Class<? extends Evaluator> interpClass = null;
+        Class<? extends Evaluator<?>> interpClass = null;
         for (Class<?> klass : impls.keySet()) {
             if (klass.isAssignableFrom(type)) {
                 interpClass = impls.get(klass);
@@ -126,7 +126,7 @@ public abstract class Evaluator<T> {
                     " Evaluator");
         }
         try {
-            Constructor<? extends Evaluator> ctor =
+            Constructor<? extends Evaluator<?>> ctor =
                 interpClass.getConstructor();
             return (Evaluator<T>)ctor.newInstance();
         } catch (Exception e) {

--- a/src/org/jdesktop/animation/timing/interpolation/KeyFrames.java
+++ b/src/org/jdesktop/animation/timing/interpolation/KeyFrames.java
@@ -42,7 +42,7 @@ package org.jdesktop.animation.timing.interpolation;
  */
 public class KeyFrames {
     
-    private KeyValues keyValues;
+    private KeyValues<Object> keyValues;
     private KeyTimes keyTimes;
     private KeyInterpolators interpolators;
     
@@ -52,7 +52,7 @@ public class KeyFrames {
      * assumes LINEAR interpolation.
      * @param keyValues values that will be assumed at each time in keyTimes
      */
-    public KeyFrames(KeyValues keyValues) {
+    public KeyFrames(KeyValues<Object> keyValues) {
         init(keyValues, null, (Interpolator)null);
     }
     
@@ -67,7 +67,7 @@ public class KeyFrames {
      * same number of elements since these structures are meant to have
      * corresponding entries; an exception is thrown otherwise.
      */
-    public KeyFrames(KeyValues keyValues, KeyTimes keyTimes) {
+    public KeyFrames(KeyValues<Object> keyValues, KeyTimes keyTimes) {
         init(keyValues, keyTimes, (Interpolator)null);
     }
     
@@ -94,7 +94,7 @@ public class KeyFrames {
      * be zero (interpolators == null), one, or one less than the size of 
      * keyTimes.
      */
-    public KeyFrames(KeyValues keyValues, KeyTimes keyTimes,
+    public KeyFrames(KeyValues<Object> keyValues, KeyTimes keyTimes,
             Interpolator... interpolators) {
         init(keyValues, keyTimes, interpolators);
     }
@@ -116,7 +116,7 @@ public class KeyFrames {
      * be zero (interpolators == null), one, or one less than the size of 
      * keyTimes.
      */
-    public KeyFrames(KeyValues keyValues, Interpolator... interpolators) {
+    public KeyFrames(KeyValues<Object> keyValues, Interpolator... interpolators) {
         init(keyValues, null, interpolators);
     }
 
@@ -124,7 +124,7 @@ public class KeyFrames {
      * Utility function called by constructors to perform common
      * initialization chores
      */
-    private void init(KeyValues keyValues, KeyTimes keyTimes,
+    private void init(KeyValues<Object> keyValues, KeyTimes keyTimes,
             Interpolator... interpolators) {
         int numFrames = keyValues.getSize();
         // If keyTimes null, create our own
@@ -158,11 +158,11 @@ public class KeyFrames {
         this.interpolators = new KeyInterpolators(numFrames - 1, interpolators);
     }
         
-    Class getType() {
+    Class<?> getType() {
         return keyValues.getType();
     }
     
-    KeyValues getKeyValues() {
+    KeyValues<Object> getKeyValues() {
         return keyValues;
     }
     

--- a/src/org/jdesktop/animation/timing/interpolation/KeyTimes.java
+++ b/src/org/jdesktop/animation/timing/interpolation/KeyTimes.java
@@ -32,6 +32,7 @@
 package org.jdesktop.animation.timing.interpolation;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Stores a list of times from 0 to 1 (the elapsed fraction of an animation
@@ -44,7 +45,7 @@ import java.util.ArrayList;
  */
 public class KeyTimes {
     
-    private ArrayList<Float> times = new ArrayList<>();
+    private List<Float> times = new ArrayList<>();
     
     /** 
      * Creates a new instance of KeyTimes.  Times should be in increasing
@@ -74,7 +75,7 @@ public class KeyTimes {
         }
     }
     
-    ArrayList getTimes() {
+    List<Float> getTimes() {
         return times;
     }
     

--- a/src/org/jdesktop/animation/timing/interpolation/KeyValues.java
+++ b/src/org/jdesktop/animation/timing/interpolation/KeyValues.java
@@ -63,7 +63,7 @@ public class KeyValues<T> {
 
     private final List<T> values = new ArrayList<>();
     private final Evaluator<T> evaluator;
-    private final Class<?> type;
+    private final Class<T> type;
     private T startValue;
 
     /**
@@ -79,7 +79,7 @@ public class KeyValues<T> {
      * found that can interpolate between the value types supplied
      */
     public static <T> KeyValues<T> create(T... params) {
-        return new KeyValues(params);
+        return new KeyValues<>(params);
     }
 
     /**
@@ -93,8 +93,8 @@ public class KeyValues<T> {
      * @throws IllegalArgumentException if params does not have at least
      * one value.
      */
-    public static <T> KeyValues<T> create(Evaluator evaluator, T... params) {
-        return new KeyValues(evaluator, params);
+    public static <T> KeyValues<T> create(Evaluator<T> evaluator, T... params) {
+        return new KeyValues<>(evaluator, params);
     }
 
     /**
@@ -108,7 +108,7 @@ public class KeyValues<T> {
     /**
      * Private constructor, called by factory method
      */
-    private KeyValues(Evaluator evaluator, T... params) {
+    private KeyValues(Evaluator<T> evaluator, T... params) {
         if (params == null) {
             throw new IllegalArgumentException("params array cannot be null");
         } else if (params.length == 0) {
@@ -120,7 +120,7 @@ public class KeyValues<T> {
             values.add(null);
         }
         Collections.addAll(values, params);
-        this.type = params.getClass().getComponentType();
+        this.type = (Class<T>) params.getClass().getComponentType();
         this.evaluator = evaluator;
     }
     
@@ -139,7 +139,7 @@ public class KeyValues<T> {
      * @return a Class value representing the type of values stored in this
      *         object
      */
-    Class<?> getType() {
+    Class<T> getType() {
         return this.type;
     }
 

--- a/src/org/jdesktop/animation/timing/interpolation/PropertySetter.java
+++ b/src/org/jdesktop/animation/timing/interpolation/PropertySetter.java
@@ -139,6 +139,7 @@ public class PropertySetter extends TimingTargetAdapter {
      * cannot be found for propertyName.
      */
     @SafeVarargs
+    @SuppressWarnings("varargs")
     public static <T> Animator createAnimator(int duration, 
             Object object, String propertyName, T... params) {
         PropertySetter ps = new PropertySetter(object, propertyName, params);
@@ -170,6 +171,7 @@ public class PropertySetter extends TimingTargetAdapter {
      * cannot be found for propertyName.
      */
     @SafeVarargs
+    @SuppressWarnings("varargs")
     public static <T> Animator createAnimator(int duration, 
             Object object, String propertyName, 
             Evaluator<?> evaluator, T... params) {
@@ -226,6 +228,7 @@ public class PropertySetter extends TimingTargetAdapter {
      * cannot be found for propertyName.
      */
     @SafeVarargs
+    @SuppressWarnings("varargs")
     public <T> PropertySetter(Object object, String propertyName, T... params) {
         this(object, propertyName, new KeyFrames(KeyValues.create(params)));
     }
@@ -254,6 +257,7 @@ public class PropertySetter extends TimingTargetAdapter {
      * cannot be found for propertyName.
      */
     @SafeVarargs
+    @SuppressWarnings("varargs")
     public <T> PropertySetter(Object object, String propertyName, 
             Evaluator<?> evaluator, T... params) {
         this(object, propertyName, 

--- a/src/org/jdesktop/animation/timing/interpolation/PropertySetter.java
+++ b/src/org/jdesktop/animation/timing/interpolation/PropertySetter.java
@@ -138,6 +138,7 @@ public class PropertySetter extends TimingTargetAdapter {
      * @throws IllegalArgumentException if appropriate set/get methods
      * cannot be found for propertyName.
      */
+    @SafeVarargs
     public static <T> Animator createAnimator(int duration, 
             Object object, String propertyName, T... params) {
         PropertySetter ps = new PropertySetter(object, propertyName, params);
@@ -168,6 +169,7 @@ public class PropertySetter extends TimingTargetAdapter {
      * @throws IllegalArgumentException if appropriate set/get methods
      * cannot be found for propertyName.
      */
+    @SafeVarargs
     public static <T> Animator createAnimator(int duration, 
             Object object, String propertyName, 
             Evaluator<?> evaluator, T... params) {
@@ -223,6 +225,7 @@ public class PropertySetter extends TimingTargetAdapter {
      * @throws IllegalArgumentException if appropriate set/get methods
      * cannot be found for propertyName.
      */
+    @SafeVarargs
     public <T> PropertySetter(Object object, String propertyName, T... params) {
         this(object, propertyName, new KeyFrames(KeyValues.create(params)));
     }
@@ -250,6 +253,7 @@ public class PropertySetter extends TimingTargetAdapter {
      * @throws IllegalArgumentException if appropriate set/get methods
      * cannot be found for propertyName.
      */
+    @SafeVarargs
     public <T> PropertySetter(Object object, String propertyName, 
             Evaluator<?> evaluator, T... params) {
         this(object, propertyName, 

--- a/src/org/jdesktop/animation/timing/interpolation/PropertySetter.java
+++ b/src/org/jdesktop/animation/timing/interpolation/PropertySetter.java
@@ -170,7 +170,7 @@ public class PropertySetter extends TimingTargetAdapter {
      */
     public static <T> Animator createAnimator(int duration, 
             Object object, String propertyName, 
-            Evaluator evaluator, T... params) {
+            Evaluator<?> evaluator, T... params) {
         PropertySetter ps = new PropertySetter(object, propertyName, evaluator, 
                 params);
         return new Animator(duration, ps);
@@ -251,7 +251,7 @@ public class PropertySetter extends TimingTargetAdapter {
      * cannot be found for propertyName.
      */
     public <T> PropertySetter(Object object, String propertyName, 
-            Evaluator evaluator, T... params) {
+            Evaluator<?> evaluator, T... params) {
         this(object, propertyName, 
                 new KeyFrames(KeyValues.create(evaluator, params)));
     }
@@ -360,7 +360,7 @@ public class PropertySetter extends TimingTargetAdapter {
      * Returns the type used in this property setter (defers to KeyFrames
      * for this information).
      */
-    private Class getType() {
+    private Class<?> getType() {
         return keyFrames.getType();
     }
     


### PR DESCRIPTION
Ich habe alle Warnungen des Java-Compilers repariert bzw. unterdrückt.

Es gibt jetzt nur noch Warnungen wegen deprecated code im package `com.explodingpixels.macwidgets`. Dieses Package scheint aus [com.explodingpixels:mac_widgets:0.9.5](http://search.maven.org/#artifactdetails%7Ccom.explodingpixels%7Cmac_widgets%7C0.9.5%7Cjar) zu stammen.
