### PR TITLE
Fix exception caused by old swingx version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,24 +35,28 @@ compileTestJava {
 
 repositories {
     maven {
-          url "https://repo.mediathekview.de/repository/maven-public/"
+        url "https://repo.mediathekview.de/repository/maven-public/"
+    }
+    flatDir {
+        dirs 'libs'
     }
 }
 
 ext {
-  swingxVersion = '1.6.5-1'
+  swingxVersion = '1.6.6-SNAPSHOT'
+  swingxGroup = ''
 }
 
 dependencies {
     compile project(':MSearch')
-    compile "org.swinglabs.swingx:swingx-action:$swingxVersion"
-    compile "org.swinglabs.swingx:swingx-autocomplete:$swingxVersion"
-    compile "org.swinglabs.swingx:swingx-beaninfo:$swingxVersion"
-    compile "org.swinglabs.swingx:swingx-common:$swingxVersion"
-    compile "org.swinglabs.swingx:swingx-core:$swingxVersion"
-    compile "org.swinglabs.swingx:swingx-graphics:$swingxVersion"
-    compile "org.swinglabs.swingx:swingx-painters:$swingxVersion"
-    compile "org.swinglabs.swingx:swingx-plaf:$swingxVersion"
+    compile "$swingxGroup:swingx-action:$swingxVersion"
+    compile "$swingxGroup:swingx-autocomplete:$swingxVersion"
+    compile "$swingxGroup:swingx-beaninfo:$swingxVersion"
+    compile "$swingxGroup:swingx-common:$swingxVersion"
+    compile "$swingxGroup:swingx-core:$swingxVersion"
+    compile "$swingxGroup:swingx-graphics:$swingxVersion"
+    compile "$swingxGroup:swingx-painters:$swingxVersion"
+    compile "$swingxGroup:swingx-plaf:$swingxVersion"
 
     compile 'com.jgoodies:jgoodies-forms:1.9.0'
     compile 'com.yuvimasory:orange-extensions:1.3.0'


### PR DESCRIPTION
Bei der Umstellung des Builds auf gradle habe ich die Version von Swingx auf `1.6.5-1` geändert, da keine neuere bei mavenCentral verfügbar war (http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.swinglabs.swingx%22). In der eingecheckten Version `1.6.6-SNAPSHOT` wurde aber wahrscheinlich diese Exception behoben. Da diese Version in keinem Repo verfügbar ist, benutzen wir jetzt wieder die eingecheckten jars.

Test mit folgendem Befehl:

```bash
cd MediathekView
./gradlew run
```

```
Exception in thread "AWT-EventQueue-0" java.lang.IllegalArgumentException: cannot add to layout: unknown constraint: LEFT
        at java.awt.BorderLayout.addLayoutComponent(BorderLayout.java:463)
        at java.awt.BorderLayout.addLayoutComponent(BorderLayout.java:424)
        at java.awt.Container.addImpl(Container.java:1127)
        at java.awt.Container.add(Container.java:973)
        at org.jdesktop.swingx.prompt.BuddySupport.addToComponentHierarchy(BuddySupport.java:72)
        at org.jdesktop.swingx.prompt.BuddySupport.ensureBuddiesAreInComponentHierarchy(BuddySupport.java:139)
        at org.jdesktop.swingx.plaf.TextUIWrapper$DefaultWrapper.replaceUIIfNeeded(TextUIWrapper.java:163)
        at org.jdesktop.swingx.plaf.TextUIWrapper.install(TextUIWrapper.java:49)
        at org.jdesktop.swingx.JXSearchField.setUseNativeSearchFieldIfPossible(JXSearchField.java:528)
        at org.jdesktop.swingx.JXSearchField.<init>(JXSearchField.java:178)
        at org.jdesktop.swingx.JXSearchField.<init>(JXSearchField.java:166)
        at mediathek.gui.ToolBar.startupFilme(ToolBar.java:147)
        at mediathek.gui.ToolBar.startup(ToolBar.java:107)
        at mediathek.gui.ToolBar.<init>(ToolBar.java:89)
        at mediathek.gui.GuiFilme.<init>(GuiFilme.java:115)
        at mediathek.MediathekGui.initTabs(MediathekGui.java:459)
        at mediathek.MediathekGui.init(MediathekGui.java:402)
        at mediathek.MediathekGui.<init>(MediathekGui.java:242)
        at mediathek.mac.MediathekGuiMac.<init>(MediathekGuiMac.java:30)
        at mediathek.Main.lambda$main$1(Main.java:210)
        at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
        at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:756)
        at java.awt.EventQueue.access$500(EventQueue.java:97)
        at java.awt.EventQueue$3.run(EventQueue.java:709)
        at java.awt.EventQueue$3.run(EventQueue.java:703)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
        at java.awt.EventQueue.dispatchEvent(EventQueue.java:726)
        at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
        at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
        at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
        at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
```