### PR TITLE
Revert "Allow starting MediathekView from command line"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,14 +4,12 @@ plugins {
     id "com.github.jk1.dependency-license-report" version "0.3.5"
 }
 apply plugin: 'java'
-apply plugin: 'application'
 apply plugin: 'distribution'
 apply from: "${project.rootDir}/gradle/eclipse.gradle"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 version = '13'
-mainClassName = 'mediathek.Main'
 
 compileJava {
     options.compilerArgs = ['-Xlint:all']


### PR DESCRIPTION
This reverts commit 3a2430eef0f456a4124a031decccca01bbe4af7b.

For reasons see: #143