### PR TITLE
bug/#258 Scrollen im Beschreibungsfenster

### DIFF
--- a/src/main/java/mediathek/gui/PanelFilmBeschreibung.java
+++ b/src/main/java/mediathek/gui/PanelFilmBeschreibung.java
@@ -29,6 +29,7 @@ import mediathek.config.MVConfig;
 import mediathek.daten.DatenDownload;
 import mediathek.gui.actions.UrlHyperlinkAction;
 import mediathek.gui.dialog.DialogFilmBeschreibung;
+import mediathek.gui.tools.NotScrollingCaret;
 import mediathek.tool.BeobMausUrl;
 import mediathek.tool.MVFont;
 import mediathek.tool.MVTable;
@@ -176,12 +177,7 @@ public class PanelFilmBeschreibung extends JPanel implements ListSelectionListen
         jEditorPane.setBorder(javax.swing.BorderFactory.createEmptyBorder(4, 4, 4, 4));
         jEditorPane.setContentType("text/html"); // NOI18N
         jEditorPane.setFont(new java.awt.Font("Dialog", 0, 24)); // NOI18N
-        jEditorPane.setCaret(new DefaultCaret() {
-            @Override
-            protected void adjustVisibility(Rectangle nloc) {
-                // do nothing, suppress scroll to bottom on setText()
-            }
-        });
+        jEditorPane.setCaret(new NotScrollingCaret());
         jScrollPane2.setViewportView(jEditorPane);
 
         jScrollPane1.setBorder(javax.swing.BorderFactory.createEmptyBorder(1, 1, 1, 1));

--- a/src/main/java/mediathek/gui/PanelFilmBeschreibung.java
+++ b/src/main/java/mediathek/gui/PanelFilmBeschreibung.java
@@ -37,6 +37,8 @@ import javax.swing.*;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.table.TableModel;
+import javax.swing.text.DefaultCaret;
+import java.awt.Rectangle;
 import java.net.URISyntaxException;
 
 @SuppressWarnings("serial")
@@ -174,6 +176,12 @@ public class PanelFilmBeschreibung extends JPanel implements ListSelectionListen
         jEditorPane.setBorder(javax.swing.BorderFactory.createEmptyBorder(4, 4, 4, 4));
         jEditorPane.setContentType("text/html"); // NOI18N
         jEditorPane.setFont(new java.awt.Font("Dialog", 0, 24)); // NOI18N
+        jEditorPane.setCaret(new DefaultCaret() {
+            @Override
+            protected void adjustVisibility(Rectangle nloc) {
+                // do nothing, suppress scroll to bottom on setText()
+            }
+        });
         jScrollPane2.setViewportView(jEditorPane);
 
         jScrollPane1.setBorder(javax.swing.BorderFactory.createEmptyBorder(1, 1, 1, 1));

--- a/src/main/java/mediathek/gui/filmInformation/MVFilmInformationLWin.java
+++ b/src/main/java/mediathek/gui/filmInformation/MVFilmInformationLWin.java
@@ -23,6 +23,7 @@ import de.mediathekview.mlib.daten.DatenFilm;
 import mediathek.config.Icons;
 import mediathek.config.MVConfig;
 import mediathek.gui.actions.UrlHyperlinkAction;
+import mediathek.gui.tools.NotScrollingCaret;
 import mediathek.tool.BeobMausUrl;
 import mediathek.tool.EscBeenden;
 import mediathek.tool.GuiFunktionen;
@@ -164,6 +165,7 @@ public class MVFilmInformationLWin extends JDialog implements IFilmInformation {
         textAreaBeschreibung.setWrapStyleWord(true);
         textAreaBeschreibung.setRows(4);
         textAreaBeschreibung.setOpaque(false);
+        textAreaBeschreibung.setCaret(new NotScrollingCaret());
 
         c.fill = GridBagConstraints.HORIZONTAL;
         c.insets = new Insets(4, 10, 4, 10);

--- a/src/main/java/mediathek/gui/filmInformation/MVFilmInformationOSX.java
+++ b/src/main/java/mediathek/gui/filmInformation/MVFilmInformationOSX.java
@@ -3,6 +3,7 @@ package mediathek.gui.filmInformation;
 import de.mediathekview.mlib.daten.DatenFilm;
 import mediathek.config.Icons;
 import mediathek.gui.actions.UrlHyperlinkAction;
+import mediathek.gui.tools.NotScrollingCaret;
 import mediathek.tool.BeobMausUrl;
 import org.jdesktop.swingx.JXHyperlink;
 
@@ -84,6 +85,7 @@ public class MVFilmInformationOSX implements IFilmInformation {
         textAreaBeschreibung.setLineWrap(true);
         textAreaBeschreibung.setWrapStyleWord(true);
         textAreaBeschreibung.setRows(4);
+        textAreaBeschreibung.setCaret(new NotScrollingCaret());
 
         jLabelFilmNeu = new JLabel();
         jLabelFilmNeu.setVisible(false);

--- a/src/main/java/mediathek/gui/tools/NotScrollingCaret.java
+++ b/src/main/java/mediathek/gui/tools/NotScrollingCaret.java
@@ -1,0 +1,18 @@
+package mediathek.gui.tools;
+
+import java.awt.Rectangle;
+
+import javax.swing.text.DefaultCaret;
+
+/**
+ * Überschreibt das Verhalten, das beim setText() auf der View zu der Cursor-Position gescrollt wird. Der Cursor steht beim setText() am
+ * Ende des gesetzten Textes, was zur Folge hat, dass hierbei immer ans Ende des Textes gescrollt wird.
+ */
+@SuppressWarnings("serial")
+public final class NotScrollingCaret extends DefaultCaret {
+
+    @Override
+    protected void adjustVisibility(Rectangle nloc) {
+        // Nichts tun, es soll nicht zum Cursor gescrollt werden.
+    }
+}


### PR DESCRIPTION
When calling setText() the underlying JLabel scrolls to the caret
position which is at the last character. This bugfix ignores this call.
See https://stackoverflow.com/a/11291548/714965