### PR TITLE
Feature/byteunitscale

### DIFF
--- a/src/main/java/mediathek/tool/ByteUnitUtil.java
+++ b/src/main/java/mediathek/tool/ByteUnitUtil.java
@@ -14,39 +14,48 @@ import java.math.BigInteger;
 import java.math.RoundingMode;
 
 /**
- * Custom Implementation of FileUtils.byteCountToDisplaySize to fix rounding bug
+ * This code is inspired by
+ * custom Implementation of FileUtils.byteCountToDisplaySize to fix rounding bug
  * taken from https://issues.apache.org/jira/browse/IO-373 (2019-09-20)
  * post from Sammy Trojette, 2016-11-01-10-09
  * 
- * quote
+ * quote:
  * Since this has just come up as an issue on our current project. I'd like to do a little necro here.
  * With this version, the displayed value is always set at least 3 numericals so: ####, ###, ##.# or #.##.
  * If anyone sees a serious issue, please give me a call.
  *
  * --
- * internal comment to Sammy Trojette's work 
- * Well, thanks for the idea and for the source code!
+ * Well, what Sammy Trojette did, is not actually exactly what e.g. Windows does. // TODO- test other OS.
+ * 1) Windows will round down, at least in displaying free space and when displaying file properties.
+ *     Rounding mode half up is not used here.
+ *     e.g. 2^30 B is displayed as 1 TB,
+ *     but (2^30-1) B is displayed as 0.99 TB
+ * 2) Windows will not display 4 digits in file properties, 
+ *    i.e. there is no displaying #,### UNIT. 
+ *    Display will reduce to 3 digits and thus display will be 0.## NEXTUNIT instead.
+ *
+ * For every value less than 1000 YiB (which corresponds to ~ 10^15 discs with 1 TB capacity each),
+ * what this tool will give is always of the form ### UNIT, ##.# UNIT or #.## UNIT 
  * 
- * Here, Sammy Trojette's idea is adapted but 
- * comparing 
- *      results of imprecise division arithmetics (BigDecimal with a rather narrow scale)
- *    to 
- *      precise byte unit file sizes 
- * I'd rather avoid due to numerical considerations. 
- * So, here division result is not used to determine the byte unit. 
- * Comparisons on BigInteger (a precise operation) are used instead.
+ * (if you had a disc with 1 TB capacity sized a cube of length 1cm, 
+ * that would be a cube of 10^5 cm side length, or 1000m.)     
  *
  */
 public class ByteUnitUtil {
 
-    private static final int DIVISION_SCALE = 5;
-	// please note:
-	// due to used rounding mode "half up", a file length of 
-	// Integer.MAX_VALUE bytes (= 2^31 - 1) will be mapped to 2.00 GB, not to 1.99 GB
-	// on other intention, consider using a different rounding mode, e.g.
-	//    private static final RoundingMode ROUNDING_MODE = RoundingMode.DOWN;
-	private static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
+    private static final int DIVISION_SCALE = 2;                         // we will never need more than 2 decimal digits for display
+	private static final RoundingMode ROUNDING_MODE = RoundingMode.DOWN; // rounding down! i.e. (2^30-1) B is to be displayed as 0.99 TB 
     
+	// enumerate Byte units with 
+	// - the size of binary prefixes (the 1024 thingy) see
+	// - the names of the more commonly known decimal prefixes (the 1000 thingy)
+	//
+	// sizes
+	// see https://de.wikipedia.org/wiki/Bin%C3%A4rpr%C3%A4fix
+	// and see org.apache.commons.io.FileUtils for actual definitions of the constants used used here
+	//
+	// names
+	// see  https://de.wikipedia.org/wiki/Vors%C3%A4tze_f%C3%BCr_Ma%C3%9Feinheiten 
     enum ByteUnit 
     {
     	// please note:
@@ -62,30 +71,68 @@ public class ByteUnitUtil {
     	// let's face it: for most people MiB is a Hollywood movie, 
     	//   and for the rest of them ... please wait for the red light to flash. BRB. Just adjusting my sunglasses...
     	
-    	YOTTABYTE("YB", ONE_YB),       // strictly speaking a YiB (2^80 B) not a YB (10^24 B) - 20.9% error!
-    	ZETTYBYTE("ZB", ONE_ZB),       // strictly speaking a ZiB (2^70 B) not a ZB (10^21 B) - 18.1% error!
-        EXABYTE("EB", ONE_EB_BI),      // strictly speaking a EiB (2^60 B) not a EB (10^18 B) - 15.3% error!
-        PETABYTE("PB", ONE_PB_BI),     // strictly speaking a PiB (2^50 B) not a PB (10^15 B) - 12.6% error!
-        TERABYTE("TB", ONE_TB_BI),     // strictly speaking a TiB (2^40 B) not a TB (10^12 B) - 10.0% error!
-        GIGABYTE("GB", ONE_GB_BI),     // strictly speaking a GiB (2^30 B) not a GB (10^9  B) -  7.4% error!
+        BYTE("bytes", BigInteger.ONE), // no unit prefix means no prefix confusion and hence 0% error
+        KILOBYTE("kB", ONE_KB_BI),     // strictly speaking a KiB (2^10 B) not a kB (10^3  B) -  2.4% error! (lower case k in kB! upper case K in KiB))
         MEGABYTE("MB", ONE_MB_BI),     // strictly speaking a MiB (2^20 B) not a MB (10^6  B) -  4.9% error!
-        KILOBYTE("kB", ONE_KB_BI),     // strictly speaking a KiB (2^10 B) not a kB (10^3  B) -  2.4% error!
-        BYTE("bytes", BigInteger.ONE); // no prefix means no prefix confusion and hence 0% error
+        GIGABYTE("GB", ONE_GB_BI),     // strictly speaking a GiB (2^30 B) not a GB (10^9  B) -  7.4% error!
+        TERABYTE("TB", ONE_TB_BI),     // strictly speaking a TiB (2^40 B) not a TB (10^12 B) - 10.0% error!
+        PETABYTE("PB", ONE_PB_BI),     // strictly speaking a PiB (2^50 B) not a PB (10^15 B) - 12.6% error!
+        EXABYTE("EB", ONE_EB_BI),      // strictly speaking a EiB (2^60 B) not a EB (10^18 B) - 15.3% error!
 
-        private final String unitName;
-        private final BigInteger byteCount;
+        // well, BigInteger may allow arbitrary precision with the shortcoming of non-hardware support for arithmetics.
+        // and hence less performance. Why not compute using long? On the other hand, 
+        // if this tool is not called millions of times, performance should not be a real issue here.  
+        
+        // With long (64 bit), we can actually handle up to 8 EiB. In other words 8 million discs with 1TB capacity each.
+        // however, this tool is meant as an alternative for org.apache.commons.io.FileUtils.byteCountToDisplaySize
+        // which accepts BigINteger input. To resemble that interface, this also uses BigInteger internally.
+        
+        // so, if we are talking BigInteger, let's not stop with 64-bit file sizes and according limit to byte units.
+        // There is more:
+    	ZETTABYTE("ZB", ONE_ZB),       // strictly speaking a ZiB (2^70 B) not a ZB (10^21 B) - 18.1% error!
+        YOTTABYTE("YB", ONE_YB),       // strictly speaking a YiB (2^80 B) not a YB (10^24 B) - 20.9% error!
+        // end of prefixes defined by BIPM. More to come 2022 on next BIPM general convention?
+        ;
+    	
+        private final String unitName;      // decimal unit name
+        private final BigInteger byteCount; // binary unit size
 
-        ByteUnit(String unitName, BigInteger byteCount) {
+        private ByteUnit(String unitName, BigInteger byteCount) {
             this.unitName = unitName;
             this.byteCount = byteCount;
         }
+        
+        ByteUnit previous() {
+        	return values()[Math.max(ordinal() - 1, 0)];
+        }
+        
+        ByteUnit next() {
+        	return values()[Math.min(ordinal() + 1, values().length-1)];
+        }
+        
         private String unitName() {
             return unitName;
         }
+        
         private BigInteger byteCount() {
             return byteCount;
         }
-
+        
+        // "logarithmic" getter
+        static ByteUnit fromBitLength(int bitLength)
+        {
+        	// bitLength of a positive integer is something like a rounded down binary logarithm
+        	// special case: BigInteger.ZERO has bitLength 0, not "negative infinity". 
+        	
+        	// the unit prefixes apply to intervals of 10 bits
+        	// [0 bits and 1-10 bits], [11 bits - 20 bits], [21 bits - 30 bits], [31 bits - 40 bits], ...
+        	// Bytes                 , KibiBytes          , MebiBytes          , GibiBytes
+        	int ordinalRaw = Math.max(bitLength - 1, 0) / 10; // BigInteger.ZERO has bitLength 0. map 0 bits to bucket 0 ("BYTE")
+        	int ordinal = Math.min(ordinalRaw, values().length - 1); // logarithm can be infinite. stop at the largest defined prefix.
+        	final ByteUnit byteUnit = values()[ordinal];
+        	// System.out.println("fromBitLength ordinal: " + ordinal + " -> " + byteUnit.name());
+			return byteUnit;
+        }
     }
 
     /**
@@ -108,6 +155,12 @@ public class ByteUnitUtil {
     	ByteUnit byteUnit = getMatchingUnitRange(fileSizeBytes);
         BigDecimal fileSizeInUnit = getFileSizeInUnit(fileSizeBytes, byteUnit);
 
+//      testing purposes        
+//		System.out.print("fileSizeBytes = " + fileSizeBytes.toString());
+//		System.out.print(" bitLength = " + fileSizeBytes.bitLength());
+//		System.out.print(" byteUnit = " + byteUnit.name());
+//		System.out.println();
+
         String numberAsText = getRoundedFileSizeInUnit(fileSizeInUnit);
         numberAsText = prettyPrintRoundedFileSizeInUnit(numberAsText);
 
@@ -115,18 +168,30 @@ public class ByteUnitUtil {
         return String.format("%s %s", numberAsText, byteUnitName);
     }
 
-	private static ByteUnit getMatchingUnitRange(BigInteger fileSizeBytes) {
-	    for (ByteUnit byteUnit : ByteUnit.values()) {
-	        BigInteger byteUnitByteCount = byteUnit.byteCount();
-	        if (fileSizeBytes.compareTo(byteUnitByteCount) >= 0) 
-	        {
-	            return byteUnit;
-	        }
+	private static ByteUnit getMatchingUnitRange(BigInteger fileSizeBytes) 
+	{
+		// compute floor(log2(filSizeBytes)) to get to a raw slot.
+		int bitLength = fileSizeBytes.bitLength();
+		ByteUnit byteUnitRaw = ByteUnit.fromBitLength(bitLength);
+		
+		// tested with MS Windows:
+		// OS will use the next higher byte unit prefix if more than 3 predecimal places would be required to represent size
+		// so, if the fileSize is 1000 times the minimum size of the byte unit or more,
+		// imitate OS behavior and step up to the next byte unit
+		BigInteger bytesRawUnit = byteUnitRaw.byteCount();
+		BigInteger thousandTimesRawUnit = bytesRawUnit.multiply(BigInteger.valueOf(1000));
+		
+	    if (fileSizeBytes.compareTo(thousandTimesRawUnit) >= 0)
+	    {
+	    	// System.out.print("exceeding 3-digit scale.");
+	    	// System.out.println("Switch from " + byteUnitRaw.name() + " to next byteUnit " + byteUnitRaw.next().name());
+	    	return byteUnitRaw.next();
 	    }
-	    return ByteUnit.BYTE;
+        return byteUnitRaw;
 	}
 
 	private static BigDecimal getFileSizeInUnit(final BigInteger fileSizeBytes, ByteUnit byteUnit) {
+		// compute the factor, how many times the byte count of the byte unit do we have (rounded to a few decimal places) 
 		BigDecimal fileSizeBytes_bd = new BigDecimal(fileSizeBytes);
 	    BigDecimal byteUnitCount_bd = new BigDecimal(byteUnit.byteCount());
 		BigDecimal fileSizeInUnit = fileSizeBytes_bd.divide(byteUnitCount_bd, DIVISION_SCALE, ROUNDING_MODE);
@@ -134,13 +199,14 @@ public class ByteUnitUtil {
 	}
 
 	private static String getRoundedFileSizeInUnit(BigDecimal fileSizeInUnit) {
-		// always round so that at least 3 digits are displayed (###, ##.#, #.##)
+		// always round so that 3 digits are displayed (###, ##.#, #.##)
 		
-		// partition interval [0,104[ into three sections:
-		// [0,10[ , [10,100[, [100, 1024[    (1 predecimal place, 2 predecimal places, 3 or 4 predecimal places)
+		// partition interval [0,1000[ into three sections:
+		// [0,10[ , [10,100[, [100, 1000[    (1 predecimal place, 2 predecimal places, 3 or 4 predecimal places)
+		// [1000, 1024[ can not occur by design of getMatchingUnitRange
 		
 	    if (fileSizeInUnit.compareTo(BigDecimal.valueOf(100.0)) >= 0) {
-	    	// fileSizeInUnit has 3 or 4 predecimal places, i.e. it's in interval [100, 1024[ : do not display any decimal places
+	    	// fileSizeInUnit with 3 predecimal places, i.e. it's in interval [100, 999[ : do not display any decimal places
 	        return fileSizeInUnit.setScale(0, ROUNDING_MODE).toString();
 	    } else if (fileSizeInUnit.compareTo(BigDecimal.valueOf(10.0)) >= 0) {
 	    	// fileSizeInUnit with 2 predecimal places, i.e. it's in interval [10,100[ : display the first decimal place only
@@ -152,12 +218,13 @@ public class ByteUnitUtil {
 	}
 
 	private static String prettyPrintRoundedFileSizeInUnit(String val) {
-		// trim zeros at the end
+		// trim trailing zeros 
         if (val.endsWith(".00")) {
             return val.substring(0, val.length() - 3);
         } else if (val.endsWith(".0")) {
             return val.substring(0, val.length() - 2);
         }
+        // else: for #.#0, the trailing 0 is not truncated
 		return val;
 	}
 

--- a/src/test/java/mediathek/tool/ByteUnitUtilTest.java
+++ b/src/test/java/mediathek/tool/ByteUnitUtilTest.java
@@ -2,6 +2,8 @@ package mediathek.tool;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.math.BigInteger;
+
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -11,24 +13,88 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 
 public class ByteUnitUtilTest {
+	
+//	public static void main(String[] args) {
+//		// execLoop();
+//		new ByteUnitUtilTest().testByteCountToDisplaySizeLong();
+//	}
+
+	@SuppressWarnings("unused")
+	private static void execLoop() {
+		// force boundary cases between byte unit buckets.
+		for (int order = 0; order < 10; order++)
+		{
+			int bits = order*10;
+			BigInteger val = BigInteger.ONE.shiftLeft(bits);
+			BigInteger pred = val.subtract(BigInteger.ONE);
+
+			BigInteger val1000 = val.multiply(BigInteger.valueOf(1000)); 
+			BigInteger val999  = val1000.subtract(BigInteger.ONE);
+			
+			execOne(pred);
+			execOne(val);
+			execOne(val999);
+			execOne(val1000);
+			System.out.println("---");
+		}
+	}
+
+	private static void execOne(BigInteger val) 
+	{
+		System.out.print("bitLength = " + val.bitLength());
+		System.out.print(" value = " + val.toString());
+
+		//		System.out.print(" bits = " + val.toString(2));
+		System.out.print(" exec: " + ByteUnitUtil.byteCountToDisplaySize(val));
+		System.out.println();
+	}
 
 	public void testByteCountToDisplaySizeLong() {
-		// please note: this test boundaries will only work for  
-		// 	ROUNDING_MODE = RoundingMode.HALF_UP in class ByteUnitUtil
+		final BigInteger twoPow20 = BigInteger.valueOf(1<<20);
+		final BigInteger twoPow30 = BigInteger.valueOf(1<<30);
 		
-		assertThat(ByteUnitUtil.byteCountToDisplaySize(Character.MAX_VALUE)).isEqualTo("64 KB");
-		assertThat(ByteUnitUtil.byteCountToDisplaySize(Integer.MAX_VALUE)).isEqualTo("2 GB");
+		// BYTE Range
 		assertThat(ByteUnitUtil.byteCountToDisplaySize(0)).isEqualTo("0 bytes");
 		assertThat(ByteUnitUtil.byteCountToDisplaySize(1)).isEqualTo("1 bytes");
-		assertThat(ByteUnitUtil.byteCountToDisplaySize(1023)).isEqualTo("1023 bytes");
-		assertThat(ByteUnitUtil.byteCountToDisplaySize(1024)).isEqualTo("1 KB");
-		assertThat(ByteUnitUtil.byteCountToDisplaySize(1030)).isEqualTo("1.01 KB");
-		assertThat(ByteUnitUtil.byteCountToDisplaySize(1224)).isEqualTo("1.20 KB");
-		assertThat(ByteUnitUtil.byteCountToDisplaySize(10239)).isEqualTo("10 KB");
-		assertThat(ByteUnitUtil.byteCountToDisplaySize(10240)).isEqualTo("10 KB");
-		assertThat(ByteUnitUtil.byteCountToDisplaySize(24832184)).isEqualTo("23.7 MB");
-		assertThat(ByteUnitUtil.byteCountToDisplaySize(38174914740L)).isEqualTo("35.6 GB");
+		
+		assertThat(ByteUnitUtil.byteCountToDisplaySize(999)).isEqualTo("999 bytes"); 
+		// KILOBYTE Range
+		assertThat(ByteUnitUtil.byteCountToDisplaySize(1000)).isEqualTo("0.97 kB"); // ! ROUND DOWN !
+		assertThat(ByteUnitUtil.byteCountToDisplaySize(1023)).isEqualTo("0.99 kB"); // ! ROUND DOWN !
+		assertThat(ByteUnitUtil.byteCountToDisplaySize(1024)).isEqualTo("1 kB");
+		assertThat(ByteUnitUtil.byteCountToDisplaySize(10239)).isEqualTo("9.99 kB"); // ! ROUND DOWN !
+		assertThat(ByteUnitUtil.byteCountToDisplaySize(10240)).isEqualTo("10 kB");
+
+		assertThat(ByteUnitUtil.byteCountToDisplaySize(1023999)).isEqualTo("999 kB"); 
+		// MEGABYTE Range
+		assertThat(ByteUnitUtil.byteCountToDisplaySize(1024000)).isEqualTo("0.97 MB"); // ! ROUND DOWN !
+		assertThat(ByteUnitUtil.byteCountToDisplaySize(1048575)).isEqualTo("0.99 MB"); // ! ROUND DOWN !
+		assertThat(ByteUnitUtil.byteCountToDisplaySize(1048576)).isEqualTo("1 MB");
+		
+		assertThat(ByteUnitUtil.byteCountToDisplaySize(1048575999)).isEqualTo("999 MB"); 
+		// GIGABYTE Range
+		assertThat(ByteUnitUtil.byteCountToDisplaySize(1048576000)).isEqualTo("0.97 GB"); // ! ROUND DOWN !
+		assertThat(ByteUnitUtil.byteCountToDisplaySize(twoPow30.subtract(BigInteger.ONE))).isEqualTo("0.99 GB"); 
+		assertThat(ByteUnitUtil.byteCountToDisplaySize(twoPow30)).isEqualTo("1 GB"); 
+		// TERABYTE Range
+		assertThat(ByteUnitUtil.byteCountToDisplaySize(twoPow20.multiply(twoPow20))).isEqualTo("1 TB");
 		assertThat(ByteUnitUtil.byteCountToDisplaySize(1374389534720L)).isEqualTo("1.25 TB");
+		
+		// PETABYTE Range
+		assertThat(ByteUnitUtil.byteCountToDisplaySize(twoPow30.multiply(twoPow20))).isEqualTo("1 PB");
+		
+		// EXABYTE Range
+		assertThat(ByteUnitUtil.byteCountToDisplaySize(twoPow30.multiply(twoPow30))).isEqualTo("1 EB");
+
+		// please note: the following test boundaries will only work for  
+		// 	ROUNDING_MODE = RoundingMode.HALF_UP in class ByteUnitUtil
+		// assertThat(ByteUnitUtil.byteCountToDisplaySize(Character.MAX_VALUE)).isEqualTo("64 kB");
+		// assertThat(ByteUnitUtil.byteCountToDisplaySize(1023)).isEqualTo("1023 bytes");
+		// assertThat(ByteUnitUtil.byteCountToDisplaySize(1030)).isEqualTo("1.01 kB");
+		// assertThat(ByteUnitUtil.byteCountToDisplaySize(1224)).isEqualTo("1.20 kB");
+		// assertThat(ByteUnitUtil.byteCountToDisplaySize(10239)).isEqualTo("10 kB");
+		// assertThat(ByteUnitUtil.byteCountToDisplaySize(24832184)).isEqualTo("23.7 MB");
+		// assertThat(ByteUnitUtil.byteCountToDisplaySize(38174914740L)).isEqualTo("35.6 GB");
 	}
 
 }


### PR DESCRIPTION
add tool ByteUnitUtil.byteCountToDisplaySize for 3 digit display of file size / disk space
-> can be considered as an alternative for org.apache.commons.io.FileUtils.byteCountToDisplaySize

pull request encouraged by Christian F in Mediathek Forum to @Rubikon