### PR TITLE
Created install4j launcher and installer for Windows 32bit 

### DIFF
--- a/.install4j/mediathekview_arm.install4j
+++ b/.install4j/mediathekview_arm.install4j
@@ -21,10 +21,12 @@
       <fileEntry mountPoint="58" file="${project.build.directory}/MediathekView.jar" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" />
       <fileEntry mountPoint="58" file="${project.build.directory}/res/MediathekView.ico" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" />
       <fileEntry mountPoint="58" file="${project.build.directory}/res/MediathekView.svg" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" />
-      <dirEntry mountPoint="58" file="${project.build.directory}/res/bin" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" entryMode="subdir" subDirectory="bin">
+      <dirEntry mountPoint="58" file="${project.build.directory}/res/bin" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" entryMode="subdir" subDirectory="bin" excludeSuffixes="*.exe">
         <exclude>
           <entry location="ffmpeg.exe" />
           <entry location="ffmpeg.txt" />
+          <entry location="ffmpeg32.exe" />
+          <entry location="ffmpeg32.txt" />
         </exclude>
       </dirEntry>
       <fileEntry mountPoint="58" file="${project.build.directory}/res/README.txt" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" />

--- a/.install4j/mediathekview_linux.install4j
+++ b/.install4j/mediathekview_linux.install4j
@@ -15,10 +15,12 @@
       <fileEntry mountPoint="58" file="${project.build.directory}/MediathekView.jar" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" />
       <fileEntry mountPoint="58" file="${project.build.directory}/res/MediathekView.ico" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" />
       <fileEntry mountPoint="58" file="${project.build.directory}/res/MediathekView.svg" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" />
-      <dirEntry mountPoint="58" file="${project.build.directory}/res/bin" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" entryMode="subdir" subDirectory="bin">
+      <dirEntry mountPoint="58" file="${project.build.directory}/res/bin" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" entryMode="subdir" subDirectory="bin" excludeSuffixes="*.exe">
         <exclude>
           <entry location="ffmpeg.exe" />
           <entry location="ffmpeg.txt" />
+          <entry location="ffmpeg32.exe" />
+          <entry location="ffmpeg32.txt" />
         </exclude>
       </dirEntry>
       <fileEntry mountPoint="58" file="${project.build.directory}/res/README.txt" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" />
@@ -29,7 +31,7 @@
       <executable name="MediathekView" iconSet="true" executableMode="gui" singleInstance="true" />
       <java mainClass="mediathek.Main" vmParameters="-Xmx2G -DexternalUpdateCheck">
         <classPath>
-          <archive location="MediathekView.jar" failOnError="false"/>
+          <archive location="MediathekView.jar" failOnError="false" />
         </classPath>
       </java>
       <desktopFile>Categories=Network;FileTransfer</desktopFile>
@@ -44,7 +46,7 @@
       <executable name="MediathekView_ipv4" iconSet="true" executableMode="gui" singleInstance="true" />
       <java mainClass="mediathek.Main" vmParameters="-Xmx2G -DexternalUpdateCheck -Djava.net.preferIPv4Stack=true">
         <classPath>
-          <archive location="MediathekView.jar" failOnError="false"/>
+          <archive location="MediathekView.jar" failOnError="false" />
         </classPath>
       </java>
       <desktopFile>Categories=Network;FileTransfer</desktopFile>
@@ -57,10 +59,9 @@
     </launcher>
     <launcher name="MediathekView_Portable" id="61" excludeFromMenu="true">
       <executable name="MediathekView_Portable" iconSet="true" executableMode="gui" />
-      <java mainClass="mediathek.Main" vmParameters="-Xmx2G -DexternalUpdateCheck"
-            arguments="Einstellungen/.mediathek3">
+      <java mainClass="mediathek.Main" vmParameters="-Xmx2G -DexternalUpdateCheck" arguments="Einstellungen/.mediathek3">
         <classPath>
-          <archive location="MediathekView.jar" failOnError="false"/>
+          <archive location="MediathekView.jar" failOnError="false" />
         </classPath>
       </java>
       <iconImageFiles>
@@ -71,15 +72,13 @@
       </iconImageFiles>
     </launcher>
   </launchers>
-  <installerGui autoUpdateDescriptorUrl="https://mediathekview.de/downloads/updates-linux.xml"
-                useAutoUpdateBaseUrl="true" autoUpdateBaseUrl="https://mediathekview.de/downloads/stabil/">
+  <installerGui autoUpdateDescriptorUrl="https://mediathekview.de/downloads/updates-linux.xml" useAutoUpdateBaseUrl="true" autoUpdateBaseUrl="https://mediathekview.de/downloads/stabil/">
     <applications>
       <application id="installer" beanClass="com.install4j.runtime.beans.applications.InstallerApplication">
         <startup>
           <screen id="1" beanClass="com.install4j.runtime.beans.screens.StartupScreen" rollbackBarrierExitCode="0">
             <actions>
-              <action id="22" beanClass="com.install4j.runtime.beans.actions.misc.RequestPrivilegesAction"
-                      actionElevationType="none" rollbackBarrierExitCode="0"/>
+              <action id="22" beanClass="com.install4j.runtime.beans.actions.misc.RequestPrivilegesAction" actionElevationType="none" rollbackBarrierExitCode="0" />
             </actions>
           </screen>
         </startup>
@@ -292,7 +291,7 @@ return console.askYesNo(message, true);
         <launcherIds>
           <launcher id="59" />
           <launcher id="60" />
-          <launcher id="61"/>
+          <launcher id="61" />
         </launcherIds>
         <startup>
           <screen id="322" beanClass="com.install4j.runtime.beans.screens.StartupScreen" rollbackBarrierExitCode="0">

--- a/.install4j/mediathekview_windows.install4j
+++ b/.install4j/mediathekview_windows.install4j
@@ -17,7 +17,9 @@
       <fileEntry mountPoint="58" file="${project.build.directory}/res/MediathekView.svg" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" />
       <dirEntry mountPoint="58" file="${project.build.directory}/res/bin" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" entryMode="subdir" subDirectory="bin">
         <exclude>
+          <entry location="ffmpeg32.exe" />
           <entry location="aria2-remote.sh" />
+          <entry location="ffmpeg32.txt" />
         </exclude>
       </dirEntry>
       <fileEntry mountPoint="58" file="${project.build.directory}/res/README.txt" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" />

--- a/.install4j/mediathekview_windows32.install4j
+++ b/.install4j/mediathekview_windows32.install4j
@@ -37,7 +37,8 @@
   <launchers>
     <launcher name="mediathekview" id="59" menuName="MediathekView">
       <executable name="MediathekView" iconSet="true" executableMode="gui" singleInstance="true"/>
-      <java mainClass="mediathek.Main" vmParameters="-Xmx2G">
+      <java mainClass="mediathek.Main"
+            vmParameters="-Xmx2G -DexternalUpdateCheck --add-exports=javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED">
         <classPath>
           <archive location="MediathekView.jar" failOnError="false"/>
         </classPath>
@@ -51,7 +52,24 @@
     </launcher>
     <launcher name="MediathekView_ipv4" id="60" menuName="MediathekView IPv4">
       <executable name="MediathekView_ipv4" iconSet="true" executableMode="gui" singleInstance="true"/>
-      <java mainClass="mediathek.Main" vmParameters="-Xmx2G -Djava.net.preferIPv4Stack=true">
+      <java mainClass="mediathek.Main"
+            vmParameters="-Xmx2G -DexternalUpdateCheck --add-exports=javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED -Djava.net.preferIPv4Stack=true">
+        <classPath>
+          <archive location="MediathekView.jar" failOnError="false"/>
+        </classPath>
+      </java>
+      <iconImageFiles>
+        <file path="${project.basedir}/.install4j/MediathekView@x16.png"/>
+        <file path="${project.basedir}/.install4j/MediathekView@x32.png"/>
+        <file path="${project.basedir}/.install4j/MediathekView@x48.png"/>
+        <file path="${project.basedir}/.install4j/MediathekView@x128.png"/>
+      </iconImageFiles>
+    </launcher>
+    <launcher name="MediathekView_Portable" id="61" excludeFromMenu="true">
+      <executable name="MediathekView_Portable" iconSet="true" executableMode="gui"/>
+      <java mainClass="mediathek.Main"
+            vmParameters="-Xmx2G -DexternalUpdateCheck --add-exports=javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED"
+            arguments="Einstellungen/.mediathek3">
         <classPath>
           <archive location="MediathekView.jar" failOnError="false"/>
         </classPath>
@@ -321,6 +339,7 @@
         <launcherIds>
           <launcher id="59"/>
           <launcher id="60"/>
+          <launcher id="61"/>
         </launcherIds>
         <startup>
           <screen id="320" beanClass="com.install4j.runtime.beans.screens.StartupScreen" rollbackBarrierExitCode="0">

--- a/.install4j/mediathekview_windows32.install4j
+++ b/.install4j/mediathekview_windows32.install4j
@@ -562,8 +562,7 @@
                   <property name="subTitle" type="string">${i18n:updater.CommentsSubTitle}</property>
                   <property name="title" type="string">${i18n:updater.CommentsTitle}</property>
                 </serializedBean>
-                <condition>false // This screen is only shown if the user clicks the "Show comments" hyperlink label in
-                  the previous screen.
+                <condition>false // This screen is only shown if the user clicks the "Show comments" hyperlink label in the previous screen.
                 </condition>
                 <validation>if (context.isConsole()) {
                   context.goBackInHistory(1);
@@ -706,8 +705,7 @@
                             <serializedBean>
                               <property name="script">
                                 <object class="com.install4j.api.beans.ScriptProperty">
-                                  <property name="value" type="string">import
-                                    com.install4j.runtime.installer.frontend.SplashProgressInterface;
+                                  <property name="value" type="string">import com.install4j.runtime.installer.frontend.SplashProgressInterface;
 
                                     List&lt;String&gt; args = new ArrayList&lt;String&gt;();
                                     String installationDirectory = context.getInstallationDirectory().getPath();

--- a/.install4j/mediathekview_windows32.install4j
+++ b/.install4j/mediathekview_windows32.install4j
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <install4j version="8.0.7" transformSequenceNumber="8">
-  <directoryPresets config="${project.basedir}/.install4j" />
+  <directoryPresets config="${project.build.directory}/res"/>
   <application name="MediathekView" applicationId="1927-5045-2127-3394" mediaDir="target" shortName="MediathekView"
                publisher="MediathekView Team" publisherWeb="https://mediathekview.de" version="${project.version}"
                macVolumeId="d594baf3c2b3424d" javaMinVersion="13">
@@ -15,57 +15,57 @@
   </application>
   <files>
     <mountPoints>
-      <mountPoint id="58" />
+      <mountPoint id="58"/>
     </mountPoints>
     <entries>
-      <fileEntry mountPoint="58" file="${project.build.directory}/MediathekView.jar" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" />
-      <fileEntry mountPoint="58" file="${project.build.directory}/res/MediathekView.ico" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" />
-      <fileEntry mountPoint="58" file="${project.build.directory}/res/MediathekView.svg" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" />
-      <dirEntry mountPoint="58" file="${project.build.directory}/res/bin" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" entryMode="subdir" subDirectory="bin">
+      <fileEntry mountPoint="58" file="${project.build.directory}/MediathekView.jar" overwriteMode="1" uninstallMode="2"
+                 overrideOverwriteMode="true" overrideUninstallMode="true"/>
+      <fileEntry mountPoint="58" file="${project.build.directory}/res/MediathekView.ico" overwriteMode="1"
+                 uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true"/>
+      <fileEntry mountPoint="58" file="${project.build.directory}/res/MediathekView.svg" overwriteMode="1"
+                 uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true"/>
+      <dirEntry mountPoint="58" file="${project.build.directory}/res/bin" overwriteMode="1" uninstallMode="2"
+                overrideOverwriteMode="true" overrideUninstallMode="true" entryMode="subdir" subDirectory="bin">
         <exclude>
-          <entry location="ffmpeg.exe" />
-          <entry location="ffmpeg.txt" />
+          <entry location="aria2-remote.sh"/>
         </exclude>
       </dirEntry>
-      <fileEntry mountPoint="58" file="${project.build.directory}/res/README.txt" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" />
+      <fileEntry mountPoint="58" file="${project.build.directory}/res/README.txt" overwriteMode="1" uninstallMode="2"
+                 overrideOverwriteMode="true" overrideUninstallMode="true"/>
     </entries>
   </files>
   <launchers>
-    <launcher name="mediathekview arm" id="323" menuName="MediathekView">
-      <executable name="MediathekView" iconSet="true" executableMode="gui" singleInstance="true" />
-      <java mainClass="mediathek.Main"
-            vmParameters="-Xmx2G -DexternalUpdateCheck --add-exports=javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED">
+    <launcher name="mediathekview" id="59" menuName="MediathekView">
+      <executable name="MediathekView" iconSet="true" executableMode="gui" singleInstance="true"/>
+      <java mainClass="mediathek.Main" vmParameters="-Xmx2G">
         <classPath>
           <archive location="MediathekView.jar" failOnError="false"/>
         </classPath>
       </java>
-      <desktopFile>Categories=Network;FileTransfer</desktopFile>
       <iconImageFiles>
-        <file path="${project.basedir}/.install4j/MediathekView@x16.png" />
-        <file path="${project.basedir}/.install4j/MediathekView@x32.png" />
-        <file path="${project.basedir}/.install4j/MediathekView@x48.png" />
-        <file path="${project.basedir}/.install4j/MediathekView@x128.png" />
+        <file path="${project.basedir}/.install4j/MediathekView@x16.png"/>
+        <file path="${project.basedir}/.install4j/MediathekView@x32.png"/>
+        <file path="${project.basedir}/.install4j/MediathekView@x48.png"/>
+        <file path="${project.basedir}/.install4j/MediathekView@x128.png"/>
       </iconImageFiles>
     </launcher>
-    <launcher name="MediathekView_ipv4 arm" id="325" menuName="MediathekView IPv4">
-      <executable name="MediathekView_ipv4" iconSet="true" executableMode="gui" singleInstance="true" />
-      <java mainClass="mediathek.Main"
-            vmParameters="-Xmx2G -DexternalUpdateCheck --add-exports=javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED -Djava.net.preferIPv4Stack=true">
+    <launcher name="MediathekView_ipv4" id="60" menuName="MediathekView IPv4">
+      <executable name="MediathekView_ipv4" iconSet="true" executableMode="gui" singleInstance="true"/>
+      <java mainClass="mediathek.Main" vmParameters="-Xmx2G -Djava.net.preferIPv4Stack=true">
         <classPath>
           <archive location="MediathekView.jar" failOnError="false"/>
         </classPath>
       </java>
-      <desktopFile>Categories=Network;FileTransfer</desktopFile>
       <iconImageFiles>
-        <file path="${project.basedir}/.install4j/MediathekView@x16.png" />
-        <file path="${project.basedir}/.install4j/MediathekView@x32.png" />
-        <file path="${project.basedir}/.install4j/MediathekView@x48.png" />
-        <file path="${project.basedir}/.install4j/MediathekView@x128.png" />
+        <file path="${project.basedir}/.install4j/MediathekView@x16.png"/>
+        <file path="${project.basedir}/.install4j/MediathekView@x32.png"/>
+        <file path="${project.basedir}/.install4j/MediathekView@x48.png"/>
+        <file path="${project.basedir}/.install4j/MediathekView@x128.png"/>
       </iconImageFiles>
     </launcher>
   </launchers>
-  <installerGui autoUpdateDescriptorUrl="https://mediathekview.de/downloads/updates-linux-armhf.xml"
-                useAutoUpdateBaseUrl="true" autoUpdateBaseUrl="https://download.mediathekview.de/stabil/">
+  <installerGui autoUpdateDescriptorUrl="https://mediathekview.de/downloads/update.xml" useAutoUpdateBaseUrl="true"
+                autoUpdateBaseUrl="https://download.mediathekview.de/stabil/">
     <applications>
       <application id="installer" beanClass="com.install4j.runtime.beans.applications.InstallerApplication">
         <startup>
@@ -77,9 +77,11 @@
           </screen>
         </startup>
         <screens>
-          <screen id="2" beanClass="com.install4j.runtime.beans.screens.WelcomeScreen" styleId="41" rollbackBarrierExitCode="0">
+          <screen id="2" beanClass="com.install4j.runtime.beans.screens.WelcomeScreen" styleId="41"
+                  rollbackBarrierExitCode="0">
             <actions>
-              <action id="7" beanClass="com.install4j.runtime.beans.actions.misc.LoadResponseFileAction" rollbackBarrierExitCode="0" multiExec="true">
+              <action id="7" beanClass="com.install4j.runtime.beans.actions.misc.LoadResponseFileAction"
+                      rollbackBarrierExitCode="0" multiExec="true">
                 <serializedBean>
                   <property name="excludedVariables" type="array" elementType="string" length="1">
                     <element index="0">sys.installationDir</element>
@@ -99,29 +101,35 @@
                 <serializedBean>
                   <property name="consoleScript">
                     <object class="com.install4j.api.beans.ScriptProperty">
-                      <property name="value" type="string">String message = context.getMessage("ConsoleWelcomeLabel", context.getApplicationName());
-return console.askOkCancel(message, true);
-</property>
+                      <property name="value" type="string">String message = context.getMessage("ConsoleWelcomeLabel",
+                        context.getApplicationName());
+                        return console.askOkCancel(message, true);
+                      </property>
                     </object>
                   </property>
                 </serializedBean>
               </formComponent>
-              <formComponent id="5" beanClass="com.install4j.runtime.beans.formcomponents.UpdateAlertComponent" useExternalParametrization="true" externalParametrizationName="Update Alert" externalParametrizationMode="include">
+              <formComponent id="5" beanClass="com.install4j.runtime.beans.formcomponents.UpdateAlertComponent"
+                             useExternalParametrization="true" externalParametrizationName="Update Alert"
+                             externalParametrizationMode="include">
                 <externalParametrizationPropertyNames>
                   <propertyName>updateCheck</propertyName>
                 </externalParametrizationPropertyNames>
               </formComponent>
-              <formComponent id="6" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent" insetTop="20">
+              <formComponent id="6" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent"
+                             insetTop="20">
                 <serializedBean>
                   <property name="labelText" type="string">${i18n:ClickNext}</property>
                 </serializedBean>
               </formComponent>
             </formComponents>
           </screen>
-          <screen id="8" beanClass="com.install4j.runtime.beans.screens.InstallationDirectoryScreen" rollbackBarrierExitCode="0">
+          <screen id="8" beanClass="com.install4j.runtime.beans.screens.InstallationDirectoryScreen"
+                  rollbackBarrierExitCode="0">
             <condition>!context.getBooleanVariable("sys.confirmedUpdateInstallation")</condition>
             <actions>
-              <action id="11" beanClass="com.install4j.runtime.beans.actions.misc.LoadResponseFileAction" rollbackBarrierExitCode="0" multiExec="true">
+              <action id="11" beanClass="com.install4j.runtime.beans.actions.misc.LoadResponseFileAction"
+                      rollbackBarrierExitCode="0" multiExec="true">
                 <serializedBean>
                   <property name="excludedVariables" type="array" elementType="string" length="1">
                     <element index="0">sys.installationDir</element>
@@ -131,14 +139,19 @@ return console.askOkCancel(message, true);
               </action>
             </actions>
             <formComponents>
-              <formComponent id="9" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent" insetBottom="25">
+              <formComponent id="9" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent"
+                             insetBottom="25">
                 <serializedBean>
                   <property name="labelText" type="string">${i18n:SelectDirLabel(${compiler:sys.fullName})}</property>
                 </serializedBean>
               </formComponent>
-              <formComponent id="10" beanClass="com.install4j.runtime.beans.formcomponents.InstallationDirectoryChooserComponent" useExternalParametrization="true" externalParametrizationName="Installation Directory Chooser" externalParametrizationMode="include">
+              <formComponent id="10"
+                             beanClass="com.install4j.runtime.beans.formcomponents.InstallationDirectoryChooserComponent"
+                             useExternalParametrization="true"
+                             externalParametrizationName="Installation Directory Chooser"
+                             externalParametrizationMode="include">
                 <serializedBean>
-                  <property name="requestFocus" type="boolean" value="true" />
+                  <property name="requestFocus" type="boolean" value="true"/>
                 </serializedBean>
                 <externalParametrizationPropertyNames>
                   <propertyName>suggestAppDir</propertyName>
@@ -156,16 +169,23 @@ return console.askOkCancel(message, true);
               </formComponent>
             </formComponents>
           </screen>
-          <screen id="15" beanClass="com.install4j.runtime.beans.screens.InstallationScreen" rollbackBarrier="true" rollbackBarrierExitCode="0">
+          <screen id="15" beanClass="com.install4j.runtime.beans.screens.InstallationScreen" rollbackBarrier="true"
+                  rollbackBarrierExitCode="0">
             <actions>
-              <action id="17" beanClass="com.install4j.runtime.beans.actions.InstallFilesAction" actionElevationType="elevated" rollbackBarrierExitCode="0" failureStrategy="quit" errorMessage="${i18n:FileCorrupted}" />
-              <action id="18" beanClass="com.install4j.runtime.beans.actions.desktop.CreateProgramGroupAction" actionElevationType="elevated" rollbackBarrierExitCode="0">
+              <action id="17" beanClass="com.install4j.runtime.beans.actions.InstallFilesAction"
+                      actionElevationType="elevated" rollbackBarrierExitCode="0" failureStrategy="quit"
+                      errorMessage="${i18n:FileCorrupted}"/>
+              <action id="18" beanClass="com.install4j.runtime.beans.actions.desktop.CreateProgramGroupAction"
+                      actionElevationType="elevated" rollbackBarrierExitCode="0">
                 <serializedBean>
-                  <property name="uninstallerMenuName" type="string">${i18n:UninstallerMenuEntry(${compiler:sys.fullName})}</property>
+                  <property name="uninstallerMenuName" type="string">
+                    ${i18n:UninstallerMenuEntry(${compiler:sys.fullName})}
+                  </property>
                 </serializedBean>
                 <condition>!context.getBooleanVariable("sys.programGroupDisabled")</condition>
               </action>
-              <action id="19" beanClass="com.install4j.runtime.beans.actions.desktop.RegisterAddRemoveAction" actionElevationType="elevated" rollbackBarrierExitCode="0">
+              <action id="19" beanClass="com.install4j.runtime.beans.actions.desktop.RegisterAddRemoveAction"
+                      actionElevationType="elevated" rollbackBarrierExitCode="0">
                 <serializedBean>
                   <property name="itemName" type="string">${compiler:sys.fullName} ${compiler:sys.version}</property>
                 </serializedBean>
@@ -179,9 +199,11 @@ return console.askOkCancel(message, true);
               </formComponent>
             </formComponents>
           </screen>
-          <screen id="20" beanClass="com.install4j.runtime.beans.screens.FinishedScreen" styleId="41" rollbackBarrierExitCode="0" finishScreen="true">
+          <screen id="20" beanClass="com.install4j.runtime.beans.screens.FinishedScreen" styleId="41"
+                  rollbackBarrierExitCode="0" finishScreen="true">
             <formComponents>
-              <formComponent id="21" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent" insetBottom="10">
+              <formComponent id="21" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent"
+                             insetBottom="10">
                 <serializedBean>
                   <property name="labelText" type="string">${form:finishedMessage}</property>
                 </serializedBean>
@@ -192,21 +214,27 @@ return console.askOkCancel(message, true);
       </application>
       <application id="uninstaller" beanClass="com.install4j.runtime.beans.applications.UninstallerApplication">
         <serializedBean>
-          <property name="customMacosExecutableName" type="string">${i18n:UninstallerMenuEntry(${compiler:sys.fullName})}</property>
-          <property name="useCustomMacosExecutableName" type="boolean" value="true" />
+          <property name="customMacosExecutableName" type="string">
+            ${i18n:UninstallerMenuEntry(${compiler:sys.fullName})}
+          </property>
+          <property name="useCustomMacosExecutableName" type="boolean" value="true"/>
         </serializedBean>
         <startup>
           <screen id="23" beanClass="com.install4j.runtime.beans.screens.StartupScreen" rollbackBarrierExitCode="0">
             <actions>
-              <action id="33" beanClass="com.install4j.runtime.beans.actions.misc.LoadResponseFileAction" rollbackBarrierExitCode="0" />
-              <action id="34" beanClass="com.install4j.runtime.beans.actions.misc.RequireInstallerPrivilegesAction" actionElevationType="none" rollbackBarrierExitCode="0" />
+              <action id="33" beanClass="com.install4j.runtime.beans.actions.misc.LoadResponseFileAction"
+                      rollbackBarrierExitCode="0"/>
+              <action id="34" beanClass="com.install4j.runtime.beans.actions.misc.RequireInstallerPrivilegesAction"
+                      actionElevationType="none" rollbackBarrierExitCode="0"/>
             </actions>
           </screen>
         </startup>
         <screens>
-          <screen id="24" beanClass="com.install4j.runtime.beans.screens.UninstallWelcomeScreen" styleId="41" rollbackBarrierExitCode="0">
+          <screen id="24" beanClass="com.install4j.runtime.beans.screens.UninstallWelcomeScreen" styleId="41"
+                  rollbackBarrierExitCode="0">
             <formComponents>
-              <formComponent id="25" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent" insetBottom="10">
+              <formComponent id="25" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent"
+                             insetBottom="10">
                 <serializedBean>
                   <property name="labelText" type="string">${form:welcomeMessage}</property>
                 </serializedBean>
@@ -216,18 +244,21 @@ return console.askOkCancel(message, true);
                 <serializedBean>
                   <property name="consoleScript">
                     <object class="com.install4j.api.beans.ScriptProperty">
-                      <property name="value" type="string">String message = context.getMessage("ConfirmUninstall", context.getApplicationName());
-return console.askYesNo(message, true);
-</property>
+                      <property name="value" type="string">String message = context.getMessage("ConfirmUninstall",
+                        context.getApplicationName());
+                        return console.askYesNo(message, true);
+                      </property>
                     </object>
                   </property>
                 </serializedBean>
               </formComponent>
             </formComponents>
           </screen>
-          <screen id="27" beanClass="com.install4j.runtime.beans.screens.UninstallationScreen" rollbackBarrierExitCode="0">
+          <screen id="27" beanClass="com.install4j.runtime.beans.screens.UninstallationScreen"
+                  rollbackBarrierExitCode="0">
             <actions>
-              <action id="29" beanClass="com.install4j.runtime.beans.actions.UninstallFilesAction" actionElevationType="elevated" rollbackBarrierExitCode="0" />
+              <action id="29" beanClass="com.install4j.runtime.beans.actions.UninstallFilesAction"
+                      actionElevationType="elevated" rollbackBarrierExitCode="0"/>
             </actions>
             <formComponents>
               <formComponent id="28" beanClass="com.install4j.runtime.beans.formcomponents.ProgressComponent">
@@ -237,10 +268,13 @@ return console.askYesNo(message, true);
               </formComponent>
             </formComponents>
           </screen>
-          <screen id="32" beanClass="com.install4j.runtime.beans.screens.UninstallFailureScreen" rollbackBarrierExitCode="0" finishScreen="true" />
-          <screen id="30" beanClass="com.install4j.runtime.beans.screens.UninstallSuccessScreen" styleId="41" rollbackBarrierExitCode="0" finishScreen="true">
+          <screen id="32" beanClass="com.install4j.runtime.beans.screens.UninstallFailureScreen"
+                  rollbackBarrierExitCode="0" finishScreen="true"/>
+          <screen id="30" beanClass="com.install4j.runtime.beans.screens.UninstallSuccessScreen" styleId="41"
+                  rollbackBarrierExitCode="0" finishScreen="true">
             <formComponents>
-              <formComponent id="31" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent" insetBottom="10">
+              <formComponent id="31" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent"
+                             insetBottom="10">
                 <serializedBean>
                   <property name="labelText" type="string">${form:successMessage}</property>
                 </serializedBean>
@@ -249,7 +283,9 @@ return console.askYesNo(message, true);
           </screen>
         </screens>
       </application>
-      <application name="Update downloader with silent version check" id="625" beanClass="com.install4j.runtime.beans.applications.CustomApplication" automaticLauncherIntegration="true" launchMode="startupSync" launchSchedule="always">
+      <application name="Update downloader with silent version check" id="319"
+                   beanClass="com.install4j.runtime.beans.applications.CustomApplication"
+                   automaticLauncherIntegration="true" launchSchedule="always" allLaunchers="false">
         <serializedBean>
           <property name="customIconImageFiles">
             <add>
@@ -279,94 +315,121 @@ return console.askYesNo(message, true);
             </add>
           </property>
           <property name="executableName" type="string">update</property>
-          <property name="useCustomIcon" type="boolean" value="true" />
+          <property name="useCustomIcon" type="boolean" value="true"/>
           <property name="windowTitle" type="string">${i18n:updater.WindowTitle("${compiler:sys.fullName}")}</property>
         </serializedBean>
+        <launcherIds>
+          <launcher id="59"/>
+          <launcher id="60"/>
+        </launcherIds>
         <startup>
-          <screen id="626" beanClass="com.install4j.runtime.beans.screens.StartupScreen" rollbackBarrierExitCode="0">
+          <screen id="320" beanClass="com.install4j.runtime.beans.screens.StartupScreen" rollbackBarrierExitCode="0">
             <actions>
-              <action id="669" beanClass="com.install4j.runtime.beans.actions.update.CheckForUpdateAction" actionElevationType="none" failureStrategy="quit">
+              <action id="363" beanClass="com.install4j.runtime.beans.actions.update.CheckForUpdateAction"
+                      actionElevationType="none" failureStrategy="quit">
                 <serializedBean>
-                  <property name="showError" type="boolean" value="false" />
+                  <property name="showError" type="boolean" value="false"/>
                   <property name="url" type="string">${installer:updatesUrl?:${compiler:sys.updatesUrl}}</property>
                   <property name="variable" type="string">updateDescriptor</property>
                 </serializedBean>
               </action>
-              <action name="Update descriptor entry" id="670" beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction" failureStrategy="quit">
+              <action name="Update descriptor entry" id="364"
+                      beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction" failureStrategy="quit">
                 <serializedBean>
-                  <property name="failIfNull" type="boolean" value="true" />
+                  <property name="failIfNull" type="boolean" value="true"/>
                   <property name="script">
                     <object class="com.install4j.api.beans.ScriptProperty">
-                      <property name="value" type="string">((UpdateDescriptor)context.getVariable("updateDescriptor")).getPossibleUpdateEntry()</property>
+                      <property name="value" type="string">
+                        ((UpdateDescriptor)context.getVariable("updateDescriptor")).getPossibleUpdateEntry()
+                      </property>
                     </object>
                   </property>
                   <property name="variableName" type="string">updateDescriptorEntry</property>
                 </serializedBean>
               </action>
-              <group name="Update available" id="671" beanClass="com.install4j.runtime.beans.groups.ActionGroup">
+              <group name="Update available" id="365" beanClass="com.install4j.runtime.beans.groups.ActionGroup">
                 <serializedBean>
                   <property name="conditionExpression">
                     <object class="com.install4j.api.beans.ScriptProperty">
-                      <property name="value" type="string">context.getVariable("updateDescriptorEntry") != null</property>
+                      <property name="value" type="string">context.getVariable("updateDescriptorEntry") != null
+                      </property>
                     </object>
                   </property>
                 </serializedBean>
                 <beans>
-                  <action name="New version" id="672" beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
+                  <action name="New version" id="366"
+                          beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
                     <serializedBean>
                       <property name="script">
                         <object class="com.install4j.api.beans.ScriptProperty">
-                          <property name="value" type="string">((UpdateDescriptorEntry)context.getVariable("updateDescriptorEntry")).getNewVersion()</property>
+                          <property name="value" type="string">
+                            ((UpdateDescriptorEntry)context.getVariable("updateDescriptorEntry")).getNewVersion()
+                          </property>
                         </object>
                       </property>
                       <property name="variableName" type="string">updaterNewVersion</property>
                     </serializedBean>
                   </action>
-                  <action name="Download size" id="673" beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
+                  <action name="Download size" id="367"
+                          beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
                     <serializedBean>
                       <property name="script">
                         <object class="com.install4j.api.beans.ScriptProperty">
-                          <property name="value" type="string">((UpdateDescriptorEntry)context.getVariable("updateDescriptorEntry")).getFileSizeVerbose()</property>
+                          <property name="value" type="string">
+                            ((UpdateDescriptorEntry)context.getVariable("updateDescriptorEntry")).getFileSizeVerbose()
+                          </property>
                         </object>
                       </property>
                       <property name="variableName" type="string">updaterDownloadSize</property>
                     </serializedBean>
                   </action>
-                  <action name="Comment" id="674" beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
+                  <action name="Comment" id="368"
+                          beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
                     <serializedBean>
                       <property name="script">
                         <object class="com.install4j.api.beans.ScriptProperty">
-                          <property name="value" type="string">((UpdateDescriptorEntry)context.getVariable("updateDescriptorEntry")).getComment()</property>
+                          <property name="value" type="string">
+                            ((UpdateDescriptorEntry)context.getVariable("updateDescriptorEntry")).getComment()
+                          </property>
                         </object>
                       </property>
                       <property name="variableName" type="string">updaterComment</property>
                     </serializedBean>
                   </action>
-                  <action name="Download URL" id="675" beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
+                  <action name="Download URL" id="369"
+                          beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
                     <serializedBean>
                       <property name="script">
                         <object class="com.install4j.api.beans.ScriptProperty">
-                          <property name="value" type="string">((UpdateDescriptorEntry)context.getVariable("updateDescriptorEntry")).getURL().toExternalForm()</property>
+                          <property name="value" type="string">
+                            ((UpdateDescriptorEntry)context.getVariable("updateDescriptorEntry")).getURL().toExternalForm()
+                          </property>
                         </object>
                       </property>
                       <property name="variableName" type="string">updaterDownloadUrl</property>
                     </serializedBean>
                   </action>
-                  <action name="Archive" id="676" beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
+                  <action name="Archive" id="370"
+                          beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
                     <serializedBean>
                       <property name="script">
                         <object class="com.install4j.api.beans.ScriptProperty">
-                          <property name="value" type="string">((UpdateDescriptorEntry)context.getVariable("updateDescriptorEntry")).isArchive() ? Boolean.TRUE : Boolean.FALSE</property>
+                          <property name="value" type="string">
+                            ((UpdateDescriptorEntry)context.getVariable("updateDescriptorEntry")).isArchive() ?
+                            Boolean.TRUE : Boolean.FALSE
+                          </property>
                         </object>
                       </property>
                       <property name="variableName" type="string">isArchive</property>
                     </serializedBean>
                   </action>
-                  <action name="DMG" id="677" beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
+                  <action name="DMG" id="371" beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
                     <serializedBean>
                       <property name="script">
                         <object class="com.install4j.api.beans.ScriptProperty">
-                          <property name="value" type="string">((UpdateDescriptorEntry)context.getVariable("updateDescriptorEntry")).getFileName().toLowerCase().endsWith(".dmg")</property>
+                          <property name="value" type="string">
+                            ((UpdateDescriptorEntry)context.getVariable("updateDescriptorEntry")).getFileName().toLowerCase().endsWith(".dmg")
+                          </property>
                         </object>
                       </property>
                       <property name="variableName" type="string">isDmg</property>
@@ -378,7 +441,7 @@ return console.askYesNo(message, true);
           </screen>
         </startup>
         <screens>
-          <group name="Update available" id="627" beanClass="com.install4j.runtime.beans.groups.ScreenGroup">
+          <group name="Update available" id="321" beanClass="com.install4j.runtime.beans.groups.ScreenGroup">
             <serializedBean>
               <property name="conditionExpression">
                 <object class="com.install4j.api.beans.ScriptProperty">
@@ -387,13 +450,15 @@ return console.askYesNo(message, true);
               </property>
             </serializedBean>
             <beans>
-              <screen name="New version available" id="628" beanClass="com.install4j.runtime.beans.screens.FormScreen">
+              <screen name="New version available" id="322" beanClass="com.install4j.runtime.beans.screens.FormScreen">
                 <serializedBean>
-                  <property name="subTitle" type="string">${i18n:updater.NewVersionAvailableSubtitle("${compiler:sys.fullName}")}</property>
+                  <property name="subTitle" type="string">
+                    ${i18n:updater.NewVersionAvailableSubtitle("${compiler:sys.fullName}")}
+                  </property>
                   <property name="title" type="string">${i18n:updater.NewVersionAvailableTitle}</property>
                 </serializedBean>
                 <formComponents>
-                  <formComponent id="629" beanClass="com.install4j.runtime.beans.formcomponents.KeyValuePairComponent">
+                  <formComponent id="323" beanClass="com.install4j.runtime.beans.formcomponents.KeyValuePairComponent">
                     <serializedBean>
                       <property name="labelText" type="string">${i18n:updater.CurrentVersionLabel}</property>
                       <property name="valueLabelColor">
@@ -404,14 +469,17 @@ return console.askYesNo(message, true);
                           <int>255</int>
                         </object>
                       </property>
-                      <property name="valueLabelFontStyle" type="enum" class="com.install4j.runtime.beans.formcomponents.FontStyle" value="BOLD" />
-                      <property name="valueLabelFontType" type="enum" class="com.install4j.runtime.beans.formcomponents.FontType" value="DERIVED" />
+                      <property name="valueLabelFontStyle" type="enum"
+                                class="com.install4j.runtime.beans.formcomponents.FontStyle" value="BOLD"/>
+                      <property name="valueLabelFontType" type="enum"
+                                class="com.install4j.runtime.beans.formcomponents.FontType" value="DERIVED"/>
                       <property name="valueLabelText" type="string">${installer:sys.version}</property>
                     </serializedBean>
                   </formComponent>
-                  <group id="630" beanClass="com.install4j.runtime.beans.groups.HorizontalFormComponentGroup">
+                  <group id="324" beanClass="com.install4j.runtime.beans.groups.HorizontalFormComponentGroup">
                     <beans>
-                      <formComponent id="631" beanClass="com.install4j.runtime.beans.formcomponents.KeyValuePairComponent">
+                      <formComponent id="325"
+                                     beanClass="com.install4j.runtime.beans.formcomponents.KeyValuePairComponent">
                         <serializedBean>
                           <property name="labelText" type="string">${i18n:updater.NewVersionLabel}</property>
                           <property name="valueLabelColor">
@@ -422,12 +490,16 @@ return console.askYesNo(message, true);
                               <int>255</int>
                             </object>
                           </property>
-                          <property name="valueLabelFontStyle" type="enum" class="com.install4j.runtime.beans.formcomponents.FontStyle" value="BOLD" />
-                          <property name="valueLabelFontType" type="enum" class="com.install4j.runtime.beans.formcomponents.FontType" value="DERIVED" />
+                          <property name="valueLabelFontStyle" type="enum"
+                                    class="com.install4j.runtime.beans.formcomponents.FontStyle" value="BOLD"/>
+                          <property name="valueLabelFontType" type="enum"
+                                    class="com.install4j.runtime.beans.formcomponents.FontType" value="DERIVED"/>
                           <property name="valueLabelText" type="string">${installer:updaterNewVersion}</property>
                         </serializedBean>
                       </formComponent>
-                      <formComponent id="632" beanClass="com.install4j.runtime.beans.formcomponents.HyperlinkActionLabelComponent" insetLeft="5">
+                      <formComponent id="326"
+                                     beanClass="com.install4j.runtime.beans.formcomponents.HyperlinkActionLabelComponent"
+                                     insetLeft="5">
                         <serializedBean>
                           <property name="actionScript">
                             <object class="com.install4j.api.beans.ScriptProperty">
@@ -436,25 +508,28 @@ return console.askYesNo(message, true);
                           </property>
                           <property name="hyperlinkText" type="string">${i18n:updater.ShowComments}</property>
                         </serializedBean>
-                        <visibilityScript> ((String)context.getVariable("updaterComment")).length() &gt; 0</visibilityScript>
+                        <visibilityScript>((String)context.getVariable("updaterComment")).length() &gt; 0
+                        </visibilityScript>
                       </formComponent>
                     </beans>
                   </group>
-                  <formComponent id="633" beanClass="com.install4j.runtime.beans.formcomponents.SpacerComponent" />
-                  <formComponent id="634" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent">
+                  <formComponent id="327" beanClass="com.install4j.runtime.beans.formcomponents.SpacerComponent"/>
+                  <formComponent id="328"
+                                 beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent">
                     <serializedBean>
                       <property name="labelText" type="string">${i18n:updater.DownloadLocationLabel}</property>
                     </serializedBean>
                   </formComponent>
-                  <formComponent id="635" beanClass="com.install4j.runtime.beans.formcomponents.DirectoryChooserComponent">
+                  <formComponent id="329"
+                                 beanClass="com.install4j.runtime.beans.formcomponents.DirectoryChooserComponent">
                     <serializedBean>
                       <property name="initialFile" type="string">${installer:sys.downloadsDir}</property>
                       <property name="labelText" type="string">${i18n:updater.DownloadToLabel}</property>
-                      <property name="manualEntryAllowed" type="boolean" value="false" />
+                      <property name="manualEntryAllowed" type="boolean" value="false"/>
                       <property name="variableName" type="string">updaterDownloadLocation</property>
                     </serializedBean>
                   </formComponent>
-                  <formComponent id="636" beanClass="com.install4j.runtime.beans.formcomponents.KeyValuePairComponent">
+                  <formComponent id="330" beanClass="com.install4j.runtime.beans.formcomponents.KeyValuePairComponent">
                     <serializedBean>
                       <property name="labelText" type="string">${i18n:updater.DownloadSizeLabel}</property>
                       <property name="valueLabelText" type="string">${installer:updaterDownloadSize}</property>
@@ -462,25 +537,30 @@ return console.askYesNo(message, true);
                   </formComponent>
                 </formComponents>
               </screen>
-              <screen name="Update message" id="637" beanClass="com.install4j.runtime.beans.screens.FormScreen">
+              <screen name="Update message" id="331" beanClass="com.install4j.runtime.beans.screens.FormScreen">
                 <serializedBean>
-                  <property name="scrollable" type="boolean" value="false" />
+                  <property name="scrollable" type="boolean" value="false"/>
                   <property name="subTitle" type="string">${i18n:updater.CommentsSubTitle}</property>
                   <property name="title" type="string">${i18n:updater.CommentsTitle}</property>
                 </serializedBean>
-                <condition>false // This screen is only shown if the user clicks the "Show comments" hyperlink label in the previous screen.
-</condition>
+                <condition>false // This screen is only shown if the user clicks the "Show comments" hyperlink label in
+                  the previous screen.
+                </condition>
                 <validation>if (context.isConsole()) {
-    context.goBackInHistory(1);
-}
-return true;</validation>
+                  context.goBackInHistory(1);
+                  }
+                  return true;
+                </validation>
                 <postActivation>WizardContext wizardContext = context.getWizardContext();
-wizardContext.setControlButtonVisible(ControlButtonType.NEXT, false);
-wizardContext.setControlButtonVisible(ControlButtonType.CANCEL, false);</postActivation>
+                  wizardContext.setControlButtonVisible(ControlButtonType.NEXT, false);
+                  wizardContext.setControlButtonVisible(ControlButtonType.CANCEL, false);
+                </postActivation>
                 <formComponents>
-                  <formComponent id="638" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent" useExternalParametrization="true" externalParametrizationName="Header" externalParametrizationMode="include">
+                  <formComponent id="332" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent"
+                                 useExternalParametrization="true" externalParametrizationName="Header"
+                                 externalParametrizationMode="include">
                     <serializedBean>
-                      <property name="hideIfBlank" type="boolean" value="true" />
+                      <property name="hideIfBlank" type="boolean" value="true"/>
                       <property name="labelText" type="string">${i18n:updater.CommentsLabel}</property>
                     </serializedBean>
                     <visibilityScript>!context.isConsole()</visibilityScript>
@@ -488,11 +568,15 @@ wizardContext.setControlButtonVisible(ControlButtonType.CANCEL, false);</postAct
                       <propertyName>labelText</propertyName>
                     </externalParametrizationPropertyNames>
                   </formComponent>
-                  <formComponent id="639" beanClass="com.install4j.runtime.beans.formcomponents.HtmlDisplayFormComponent" useExternalParametrization="true" externalParametrizationName="HTML display" externalParametrizationMode="include">
+                  <formComponent id="333"
+                                 beanClass="com.install4j.runtime.beans.formcomponents.HtmlDisplayFormComponent"
+                                 useExternalParametrization="true" externalParametrizationName="HTML display"
+                                 externalParametrizationMode="include">
                     <serializedBean>
                       <property name="displayedText" type="string">${installer:updaterComment}</property>
-                      <property name="fillVertical" type="boolean" value="true" />
-                      <property name="textSource" type="enum" class="com.install4j.runtime.beans.screens.components.TextSource" value="DIRECT" />
+                      <property name="fillVertical" type="boolean" value="true"/>
+                      <property name="textSource" type="enum"
+                                class="com.install4j.runtime.beans.screens.components.TextSource" value="DIRECT"/>
                     </serializedBean>
                     <externalParametrizationPropertyNames>
                       <propertyName>textSource</propertyName>
@@ -501,40 +585,46 @@ wizardContext.setControlButtonVisible(ControlButtonType.CANCEL, false);</postAct
                       <propertyName>variableName</propertyName>
                     </externalParametrizationPropertyNames>
                   </formComponent>
-                  <formComponent id="640" beanClass="com.install4j.runtime.beans.formcomponents.ConsoleHandlerFormComponent">
+                  <formComponent id="334"
+                                 beanClass="com.install4j.runtime.beans.formcomponents.ConsoleHandlerFormComponent">
                     <serializedBean>
                       <property name="consoleScript">
                         <object class="com.install4j.api.beans.ScriptProperty">
                           <property name="value" type="string">console.waitForEnter();
-return true;
-</property>
+                            return true;
+                          </property>
                         </object>
                       </property>
                     </serializedBean>
                   </formComponent>
                 </formComponents>
               </screen>
-              <screen name="Download new version" id="641" beanClass="com.install4j.runtime.beans.screens.FormScreen">
+              <screen name="Download new version" id="335" beanClass="com.install4j.runtime.beans.screens.FormScreen">
                 <serializedBean>
                   <property name="subTitle" type="string">${i18n:updater.DownloadSubTitle}</property>
                   <property name="title" type="string">${i18n:updater.DownloadTitle}</property>
                 </serializedBean>
                 <postActivation>context.getWizardContext().setControlButtonVisible(ControlButtonType.NEXT, false);
-context.getWizardContext().setControlButtonVisible(ControlButtonType.PREVIOUS, false);
-context.goForward(1, true, true);
-</postActivation>
+                  context.getWizardContext().setControlButtonVisible(ControlButtonType.PREVIOUS, false);
+                  context.goForward(1, true, true);
+                </postActivation>
                 <actions>
-                  <action name="Download location" id="642" beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
+                  <action name="Download location" id="336"
+                          beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
                     <serializedBean>
                       <property name="script">
                         <object class="com.install4j.api.beans.ScriptProperty">
-                          <property name="value" type="string">context.getVariable("updaterDownloadLocation") + File.separator + ((UpdateDescriptorEntry)context.getVariable("updateDescriptorEntry")).getFileName()</property>
+                          <property name="value" type="string">context.getVariable("updaterDownloadLocation") +
+                            File.separator +
+                            ((UpdateDescriptorEntry)context.getVariable("updateDescriptorEntry")).getFileName()
+                          </property>
                         </object>
                       </property>
                       <property name="variableName" type="string">updaterDownloadFile</property>
                     </serializedBean>
                   </action>
-                  <action id="643" beanClass="com.install4j.runtime.beans.actions.net.DownloadFileAction" actionElevationType="elevated" failureStrategy="quit">
+                  <action id="337" beanClass="com.install4j.runtime.beans.actions.net.DownloadFileAction"
+                          actionElevationType="elevated" failureStrategy="quit">
                     <serializedBean>
                       <property name="targetFile">
                         <object class="java.io.File">
@@ -544,7 +634,8 @@ context.goForward(1, true, true);
                       <property name="url" type="string">${installer:updaterDownloadUrl}</property>
                     </serializedBean>
                   </action>
-                  <action id="644" beanClass="com.install4j.runtime.beans.actions.files.SetModeAction" actionElevationType="elevated">
+                  <action id="338" beanClass="com.install4j.runtime.beans.actions.files.SetModeAction"
+                          actionElevationType="elevated">
                     <serializedBean>
                       <property name="files" type="array" class="java.io.File" length="1">
                         <element index="0">
@@ -558,7 +649,9 @@ context.goForward(1, true, true);
                   </action>
                 </actions>
                 <formComponents>
-                  <formComponent id="645" beanClass="com.install4j.runtime.beans.formcomponents.ProgressComponent" useExternalParametrization="true" externalParametrizationName="Directory" externalParametrizationMode="include">
+                  <formComponent id="339" beanClass="com.install4j.runtime.beans.formcomponents.ProgressComponent"
+                                 useExternalParametrization="true" externalParametrizationName="Directory"
+                                 externalParametrizationMode="include">
                     <externalParametrizationPropertyNames>
                       <propertyName>statusVisible</propertyName>
                       <propertyName>initialStatusMessage</propertyName>
@@ -566,54 +659,66 @@ context.goForward(1, true, true);
                   </formComponent>
                 </formComponents>
               </screen>
-              <group name="Finish" id="646" beanClass="com.install4j.runtime.beans.groups.ScreenGroup">
+              <group name="Finish" id="340" beanClass="com.install4j.runtime.beans.groups.ScreenGroup">
                 <beans>
-                  <screen name="Finish" id="647" beanClass="com.install4j.runtime.beans.screens.FormScreen" styleId="41" finishScreen="true">
+                  <screen name="Finish" id="341" beanClass="com.install4j.runtime.beans.screens.FormScreen" styleId="41"
+                          finishScreen="true">
                     <serializedBean>
                       <property name="title" type="string">${i18n:updater.FinishTitle}</property>
                     </serializedBean>
-                    <condition>!(context.getBooleanVariable("isArchive") &amp;&amp; context.getBooleanVariable("isDmg"))</condition>
+                    <condition>!(context.getBooleanVariable("isArchive") &amp;&amp;
+                      context.getBooleanVariable("isDmg"))
+                    </condition>
                     <actions>
-                      <group name="Execute installer" id="648" beanClass="com.install4j.runtime.beans.groups.ActionGroup">
+                      <group name="Execute installer" id="342"
+                             beanClass="com.install4j.runtime.beans.groups.ActionGroup">
                         <serializedBean>
                           <property name="conditionExpression">
                             <object class="com.install4j.api.beans.ScriptProperty">
-                              <property name="value" type="string">!context.getBooleanVariable("isArchive") &amp;&amp; ((Integer)context.getVariable("updaterLaunchSelection")).intValue() == 0</property>
+                              <property name="value" type="string">!context.getBooleanVariable("isArchive") &amp;&amp;
+                                ((Integer)context.getVariable("updaterLaunchSelection")).intValue() == 0
+                              </property>
                             </object>
                           </property>
                         </serializedBean>
                         <beans>
-                          <action name="Set installer arguments" id="649" beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
+                          <action name="Set installer arguments" id="343"
+                                  beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
                             <serializedBean>
                               <property name="script">
                                 <object class="com.install4j.api.beans.ScriptProperty">
-                                  <property name="value" type="string">import com.install4j.runtime.installer.frontend.SplashProgressInterface;
+                                  <property name="value" type="string">import
+                                    com.install4j.runtime.installer.frontend.SplashProgressInterface;
 
-List&lt;String&gt; args = new ArrayList&lt;String&gt;();
-String installationDirectory = context.getInstallationDirectory().getPath();
-if (context.isUnattended()) {
-    args.add("-q");
-    args.add("-wait");
-    args.add("20");
-    if (context.getProgressInterface() instanceof SplashProgressInterface) {
-        args.add("-splash");
-        args.add("Installing");
-    }
-} else if (context.isConsole()) {
-    args.add("-c");
-}
- args.add("-dir");
- args.add(installationDirectory);
- 
- return args.toArray(new String[args.size()]);
-</property>
+                                    List&lt;String&gt; args = new ArrayList&lt;String&gt;();
+                                    String installationDirectory = context.getInstallationDirectory().getPath();
+                                    if (context.isUnattended()) {
+                                    args.add("-q");
+                                    args.add("-wait");
+                                    args.add("20");
+                                    if (context.getProgressInterface() instanceof SplashProgressInterface) {
+                                    args.add("-splash");
+                                    args.add("Installing");
+                                    }
+                                    } else if (context.isConsole()) {
+                                    args.add("-c");
+                                    }
+                                    args.add("-dir");
+                                    args.add(installationDirectory);
+
+                                    return args.toArray(new String[args.size()]);
+                                  </property>
                                 </object>
                               </property>
                               <property name="variableName" type="string">installerArguments</property>
                             </serializedBean>
                           </action>
-                          <action id="650" beanClass="com.install4j.runtime.beans.actions.update.ShutdownCallingLauncherAction" actionElevationType="none" />
-                          <action id="651" beanClass="com.install4j.runtime.beans.actions.misc.RunExecutableAction" actionElevationType="elevated" failureStrategy="quit" errorMessage="${i18n:updater.LaunchError}">
+                          <action id="344"
+                                  beanClass="com.install4j.runtime.beans.actions.update.ShutdownCallingLauncherAction"
+                                  actionElevationType="none"/>
+                          <action id="345" beanClass="com.install4j.runtime.beans.actions.misc.RunExecutableAction"
+                                  actionElevationType="elevated" failureStrategy="quit"
+                                  errorMessage="${i18n:updater.LaunchError}">
                             <serializedBean>
                               <property name="arguments" type="array" elementType="string" length="1">
                                 <element index="0">${installer:installerArguments}</element>
@@ -634,36 +739,45 @@ if (context.isUnattended()) {
                       </group>
                     </actions>
                     <formComponents>
-                      <formComponent id="652" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent" insetBottom="20" useExternalParametrization="true" externalParametrizationName="Header" externalParametrizationMode="include">
+                      <formComponent id="346"
+                                     beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent"
+                                     insetBottom="20" useExternalParametrization="true"
+                                     externalParametrizationName="Header" externalParametrizationMode="include">
                         <serializedBean>
-                          <property name="hideIfBlank" type="boolean" value="true" />
+                          <property name="hideIfBlank" type="boolean" value="true"/>
                         </serializedBean>
                         <visibilityScript>!context.isConsole()</visibilityScript>
                         <externalParametrizationPropertyNames>
                           <propertyName>labelText</propertyName>
                         </externalParametrizationPropertyNames>
                       </formComponent>
-                      <formComponent id="653" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent" insetBottom="20" useExternalParametrization="true" externalParametrizationName="Header" externalParametrizationMode="include">
+                      <formComponent id="347"
+                                     beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent"
+                                     insetBottom="20" useExternalParametrization="true"
+                                     externalParametrizationName="Header" externalParametrizationMode="include">
                         <serializedBean>
-                          <property name="hideIfBlank" type="boolean" value="true" />
-                          <property name="labelText" type="string">${i18n:updater.FinishInfoText("${compiler:sys.fullName}")}</property>
+                          <property name="hideIfBlank" type="boolean" value="true"/>
+                          <property name="labelText" type="string">
+                            ${i18n:updater.FinishInfoText("${compiler:sys.fullName}")}
+                          </property>
                         </serializedBean>
                         <visibilityScript>!context.isConsole()</visibilityScript>
                         <externalParametrizationPropertyNames>
                           <propertyName>labelText</propertyName>
                         </externalParametrizationPropertyNames>
                       </formComponent>
-                      <formComponent id="654" beanClass="com.install4j.runtime.beans.formcomponents.LabelComponent">
+                      <formComponent id="348" beanClass="com.install4j.runtime.beans.formcomponents.LabelComponent">
                         <serializedBean>
                           <property name="labelText" type="string">${i18n:updater.LaunchUpdaterQuestion}</property>
                         </serializedBean>
                       </formComponent>
-                      <formComponent id="655" beanClass="com.install4j.runtime.beans.formcomponents.SpacerComponent">
+                      <formComponent id="349" beanClass="com.install4j.runtime.beans.formcomponents.SpacerComponent">
                         <serializedBean>
-                          <property name="height" type="int" value="5" />
+                          <property name="height" type="int" value="5"/>
                         </serializedBean>
                       </formComponent>
-                      <formComponent id="656" beanClass="com.install4j.runtime.beans.formcomponents.RadiobuttonsComponent">
+                      <formComponent id="350"
+                                     beanClass="com.install4j.runtime.beans.formcomponents.RadiobuttonsComponent">
                         <serializedBean>
                           <property name="radioButtonLabels" type="array" elementType="string" length="2">
                             <element index="0">${i18n:updater.LaunchUpdaterLabel}</element>
@@ -673,47 +787,60 @@ if (context.isUnattended()) {
                         </serializedBean>
                         <visibilityScript>!context.getBooleanVariable("isArchive")</visibilityScript>
                       </formComponent>
-                      <formComponent id="657" beanClass="com.install4j.runtime.beans.formcomponents.HyperlinkActionLabelComponent">
+                      <formComponent id="351"
+                                     beanClass="com.install4j.runtime.beans.formcomponents.HyperlinkActionLabelComponent">
                         <serializedBean>
                           <property name="actionScript">
                             <object class="com.install4j.api.beans.ScriptProperty">
-                              <property name="value" type="string">Util.showPath((String)context.getVariable("updaterDownloadFile"));</property>
+                              <property name="value" type="string">
+                                Util.showPath((String)context.getVariable("updaterDownloadFile"));
+                              </property>
                             </object>
                           </property>
-                          <property name="hyperlinkText" type="string">${i18n:updater.OpenContainingFolderLabel}</property>
+                          <property name="hyperlinkText" type="string">${i18n:updater.OpenContainingFolderLabel}
+                          </property>
                         </serializedBean>
                         <visibilityScript>!context.isConsole()</visibilityScript>
                       </formComponent>
-                      <formComponent id="658" beanClass="com.install4j.runtime.beans.formcomponents.ProgressComponent">
+                      <formComponent id="352" beanClass="com.install4j.runtime.beans.formcomponents.ProgressComponent">
                         <serializedBean>
-                          <property name="detailVisible" type="boolean" value="false" />
-                          <property name="hideInitially" type="boolean" value="true" />
+                          <property name="detailVisible" type="boolean" value="false"/>
+                          <property name="hideInitially" type="boolean" value="true"/>
                         </serializedBean>
                       </formComponent>
                     </formComponents>
                   </screen>
-                  <screen name="Finish DMG Archive" id="659" beanClass="com.install4j.runtime.beans.screens.FormScreen" styleId="41" finishScreen="true">
+                  <screen name="Finish DMG Archive" id="353" beanClass="com.install4j.runtime.beans.screens.FormScreen"
+                          styleId="41" finishScreen="true">
                     <serializedBean>
                       <property name="title" type="string">${i18n:updater.FinishTitle}</property>
                     </serializedBean>
-                    <condition>context.getBooleanVariable("isArchive") &amp;&amp; context.getBooleanVariable("isDmg")</condition>
+                    <condition>context.getBooleanVariable("isArchive") &amp;&amp; context.getBooleanVariable("isDmg")
+                    </condition>
                     <actions>
-                      <group name="Execute installer" id="660" beanClass="com.install4j.runtime.beans.groups.ActionGroup">
+                      <group name="Execute installer" id="354"
+                             beanClass="com.install4j.runtime.beans.groups.ActionGroup">
                         <serializedBean>
                           <property name="conditionExpression">
                             <object class="com.install4j.api.beans.ScriptProperty">
-                              <property name="value" type="string">context.getBooleanVariable("updaterOpenDmg")</property>
+                              <property name="value" type="string">context.getBooleanVariable("updaterOpenDmg")
+                              </property>
                             </object>
                           </property>
                         </serializedBean>
                         <beans>
-                          <action id="661" beanClass="com.install4j.runtime.beans.actions.update.ShutdownCallingLauncherAction" actionElevationType="none" />
-                          <action name="Open DMG" id="662" beanClass="com.install4j.runtime.beans.actions.control.RunScriptAction">
+                          <action id="355"
+                                  beanClass="com.install4j.runtime.beans.actions.update.ShutdownCallingLauncherAction"
+                                  actionElevationType="none"/>
+                          <action name="Open DMG" id="356"
+                                  beanClass="com.install4j.runtime.beans.actions.control.RunScriptAction">
                             <serializedBean>
                               <property name="script">
                                 <object class="com.install4j.api.beans.ScriptProperty">
-                                  <property name="value" type="string">Util.showPath((String)context.getVariable("updaterDownloadFile"));
-return true;</property>
+                                  <property name="value" type="string">
+                                    Util.showPath((String)context.getVariable("updaterDownloadFile"));
+                                    return true;
+                                  </property>
                                 </object>
                               </property>
                             </serializedBean>
@@ -722,46 +849,55 @@ return true;</property>
                       </group>
                     </actions>
                     <formComponents>
-                      <formComponent id="663" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent" insetBottom="20" useExternalParametrization="true" externalParametrizationName="Header" externalParametrizationMode="include">
+                      <formComponent id="357"
+                                     beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent"
+                                     insetBottom="20" useExternalParametrization="true"
+                                     externalParametrizationName="Header" externalParametrizationMode="include">
                         <serializedBean>
-                          <property name="hideIfBlank" type="boolean" value="true" />
+                          <property name="hideIfBlank" type="boolean" value="true"/>
                         </serializedBean>
                         <visibilityScript>!context.isConsole()</visibilityScript>
                         <externalParametrizationPropertyNames>
                           <propertyName>labelText</propertyName>
                         </externalParametrizationPropertyNames>
                       </formComponent>
-                      <formComponent id="664" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent" insetBottom="20" useExternalParametrization="true" externalParametrizationName="Header" externalParametrizationMode="include">
+                      <formComponent id="358"
+                                     beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent"
+                                     insetBottom="20" useExternalParametrization="true"
+                                     externalParametrizationName="Header" externalParametrizationMode="include">
                         <serializedBean>
-                          <property name="hideIfBlank" type="boolean" value="true" />
-                          <property name="labelText" type="string">${i18n:updater.FinishInfoText("${compiler:sys.fullName}")}</property>
+                          <property name="hideIfBlank" type="boolean" value="true"/>
+                          <property name="labelText" type="string">
+                            ${i18n:updater.FinishInfoText("${compiler:sys.fullName}")}
+                          </property>
                         </serializedBean>
                         <visibilityScript>!context.isConsole()</visibilityScript>
                         <externalParametrizationPropertyNames>
                           <propertyName>labelText</propertyName>
                         </externalParametrizationPropertyNames>
                       </formComponent>
-                      <formComponent id="665" beanClass="com.install4j.runtime.beans.formcomponents.LabelComponent">
+                      <formComponent id="359" beanClass="com.install4j.runtime.beans.formcomponents.LabelComponent">
                         <serializedBean>
                           <property name="labelText" type="string">${i18n:updater.LaunchUpdaterQuestion}</property>
                         </serializedBean>
                       </formComponent>
-                      <formComponent id="666" beanClass="com.install4j.runtime.beans.formcomponents.SpacerComponent">
+                      <formComponent id="360" beanClass="com.install4j.runtime.beans.formcomponents.SpacerComponent">
                         <serializedBean>
-                          <property name="height" type="int" value="5" />
+                          <property name="height" type="int" value="5"/>
                         </serializedBean>
                       </formComponent>
-                      <formComponent id="667" beanClass="com.install4j.runtime.beans.formcomponents.CheckboxComponent">
+                      <formComponent id="361" beanClass="com.install4j.runtime.beans.formcomponents.CheckboxComponent">
                         <serializedBean>
-                          <property name="checkboxText" type="string">${i18n:updater.OpenContainingFolderLabel}</property>
-                          <property name="initiallySelected" type="boolean" value="true" />
+                          <property name="checkboxText" type="string">${i18n:updater.OpenContainingFolderLabel}
+                          </property>
+                          <property name="initiallySelected" type="boolean" value="true"/>
                           <property name="variableName" type="string">updaterOpenDmg</property>
                         </serializedBean>
                       </formComponent>
-                      <formComponent id="668" beanClass="com.install4j.runtime.beans.formcomponents.ProgressComponent">
+                      <formComponent id="362" beanClass="com.install4j.runtime.beans.formcomponents.ProgressComponent">
                         <serializedBean>
-                          <property name="detailVisible" type="boolean" value="false" />
-                          <property name="hideInitially" type="boolean" value="true" />
+                          <property name="detailVisible" type="boolean" value="false"/>
+                          <property name="hideInitially" type="boolean" value="true"/>
                         </serializedBean>
                       </formComponent>
                     </formComponents>
@@ -776,24 +912,30 @@ return true;</property>
     <styles defaultStyleId="35">
       <style name="Standard" id="35" beanClass="com.install4j.runtime.beans.styles.FormStyle">
         <formComponents>
-          <formComponent name="Header" id="36" beanClass="com.install4j.runtime.beans.styles.NestedStyleComponent" insetTop="0" insetBottom="0">
+          <formComponent name="Header" id="36" beanClass="com.install4j.runtime.beans.styles.NestedStyleComponent"
+                         insetTop="0" insetBottom="0">
             <serializedBean>
               <property name="styleId" type="string">48</property>
             </serializedBean>
           </formComponent>
           <group name="Main" id="37" beanClass="com.install4j.runtime.beans.groups.VerticalFormComponentGroup">
             <beans>
-              <formComponent id="38" beanClass="com.install4j.runtime.beans.styles.ContentComponent" insetTop="10" insetLeft="20" insetBottom="10" insetRight="20" />
-              <formComponent name="Watermark" id="39" beanClass="com.install4j.runtime.beans.formcomponents.SeparatorComponent" insetTop="0" insetLeft="5" insetBottom="0" useExternalParametrization="true" externalParametrizationName="Custom watermark" externalParametrizationMode="include">
+              <formComponent id="38" beanClass="com.install4j.runtime.beans.styles.ContentComponent" insetTop="10"
+                             insetLeft="20" insetBottom="10" insetRight="20"/>
+              <formComponent name="Watermark" id="39"
+                             beanClass="com.install4j.runtime.beans.formcomponents.SeparatorComponent" insetTop="0"
+                             insetLeft="5" insetBottom="0" useExternalParametrization="true"
+                             externalParametrizationName="Custom watermark" externalParametrizationMode="include">
                 <serializedBean>
-                  <property name="enabledTitleText" type="boolean" value="false" />
+                  <property name="enabledTitleText" type="boolean" value="false"/>
                   <property name="labelText" type="string">install4j</property>
                 </serializedBean>
                 <externalParametrizationPropertyNames>
                   <propertyName>labelText</propertyName>
                 </externalParametrizationPropertyNames>
               </formComponent>
-              <formComponent name="Footer" id="40" beanClass="com.install4j.runtime.beans.styles.NestedStyleComponent" insetTop="0" insetBottom="0">
+              <formComponent name="Footer" id="40" beanClass="com.install4j.runtime.beans.styles.NestedStyleComponent"
+                             insetTop="0" insetBottom="0">
                 <serializedBean>
                   <property name="styleId" type="string">52</property>
                 </serializedBean>
@@ -804,7 +946,9 @@ return true;</property>
       </style>
       <style name="Banner" id="41" beanClass="com.install4j.runtime.beans.styles.FormStyle">
         <formComponents>
-          <group id="42" beanClass="com.install4j.runtime.beans.groups.VerticalFormComponentGroup" useExternalParametrization="true" externalParametrizationName="Customize banner image" externalParametrizationMode="include">
+          <group id="42" beanClass="com.install4j.runtime.beans.groups.VerticalFormComponentGroup"
+                 useExternalParametrization="true" externalParametrizationName="Customize banner image"
+                 externalParametrizationMode="include">
             <serializedBean>
               <property name="backgroundColor">
                 <object class="java.awt.Color">
@@ -816,7 +960,7 @@ return true;</property>
               </property>
               <property name="borderSides">
                 <object class="com.install4j.runtime.beans.formcomponents.BorderSides">
-                  <property name="bottom" type="boolean" value="true" />
+                  <property name="bottom" type="boolean" value="true"/>
                 </object>
               </property>
               <property name="imageEdgeBackgroundColor">
@@ -827,7 +971,7 @@ return true;</property>
                   <int>255</int>
                 </object>
               </property>
-              <property name="imageEdgeBorder" type="boolean" value="true" />
+              <property name="imageEdgeBorder" type="boolean" value="true"/>
               <property name="imageFile">
                 <object class="com.install4j.api.beans.ExternalFile">
                   <string>${compiler:sys.install4jHome}/resource/styles/wizard.png</string>
@@ -845,13 +989,16 @@ return true;</property>
             <beans>
               <formComponent id="43" beanClass="com.install4j.runtime.beans.styles.ScreenTitleComponent" insetTop="0">
                 <serializedBean>
-                  <property name="labelFontSizePercent" type="int" value="130" />
-                  <property name="labelFontStyle" type="enum" class="com.install4j.runtime.beans.formcomponents.FontStyle" value="BOLD" />
-                  <property name="labelFontType" type="enum" class="com.install4j.runtime.beans.formcomponents.FontType" value="DERIVED" />
+                  <property name="labelFontSizePercent" type="int" value="130"/>
+                  <property name="labelFontStyle" type="enum"
+                            class="com.install4j.runtime.beans.formcomponents.FontStyle" value="BOLD"/>
+                  <property name="labelFontType" type="enum" class="com.install4j.runtime.beans.formcomponents.FontType"
+                            value="DERIVED"/>
                 </serializedBean>
               </formComponent>
-              <formComponent id="44" beanClass="com.install4j.runtime.beans.formcomponents.SeparatorComponent" />
-              <formComponent id="45" beanClass="com.install4j.runtime.beans.styles.ContentComponent" insetTop="10" insetBottom="0" />
+              <formComponent id="44" beanClass="com.install4j.runtime.beans.formcomponents.SeparatorComponent"/>
+              <formComponent id="45" beanClass="com.install4j.runtime.beans.styles.ContentComponent" insetTop="10"
+                             insetBottom="0"/>
             </beans>
             <externalParametrizationPropertyNames>
               <propertyName>imageAnchor</propertyName>
@@ -870,12 +1017,14 @@ return true;</property>
         <beans>
           <style name="Standard header" id="48" beanClass="com.install4j.runtime.beans.styles.FormStyle">
             <serializedBean>
-              <property name="fillVertical" type="boolean" value="false" />
-              <property name="standalone" type="boolean" value="false" />
-              <property name="verticalAnchor" type="enum" class="com.install4j.api.beans.Anchor" value="NORTH" />
+              <property name="fillVertical" type="boolean" value="false"/>
+              <property name="standalone" type="boolean" value="false"/>
+              <property name="verticalAnchor" type="enum" class="com.install4j.api.beans.Anchor" value="NORTH"/>
             </serializedBean>
             <formComponents>
-              <group id="49" beanClass="com.install4j.runtime.beans.groups.VerticalFormComponentGroup" useExternalParametrization="true" externalParametrizationName="Customize title bar" externalParametrizationMode="include">
+              <group id="49" beanClass="com.install4j.runtime.beans.groups.VerticalFormComponentGroup"
+                     useExternalParametrization="true" externalParametrizationName="Customize title bar"
+                     externalParametrizationMode="include">
                 <serializedBean>
                   <property name="backgroundColor">
                     <object class="java.awt.Color">
@@ -887,11 +1036,11 @@ return true;</property>
                   </property>
                   <property name="borderSides">
                     <object class="com.install4j.runtime.beans.formcomponents.BorderSides">
-                      <property name="bottom" type="boolean" value="true" />
+                      <property name="bottom" type="boolean" value="true"/>
                     </object>
                   </property>
-                  <property name="imageAnchor" type="enum" class="com.install4j.api.beans.Anchor" value="NORTHEAST" />
-                  <property name="imageEdgeBorderWidth" type="int" value="2" />
+                  <property name="imageAnchor" type="enum" class="com.install4j.api.beans.Anchor" value="NORTHEAST"/>
+                  <property name="imageEdgeBorderWidth" type="int" value="2"/>
                   <property name="imageFile">
                     <object class="com.install4j.api.beans.ExternalFile">
                       <string>icon:${installer:sys.installerApplicationMode}_header.png</string>
@@ -915,15 +1064,20 @@ return true;</property>
                   </property>
                 </serializedBean>
                 <beans>
-                  <formComponent name="Title" id="50" beanClass="com.install4j.runtime.beans.styles.ScreenTitleComponent">
+                  <formComponent name="Title" id="50"
+                                 beanClass="com.install4j.runtime.beans.styles.ScreenTitleComponent">
                     <serializedBean>
-                      <property name="labelFontStyle" type="enum" class="com.install4j.runtime.beans.formcomponents.FontStyle" value="BOLD" />
-                      <property name="labelFontType" type="enum" class="com.install4j.runtime.beans.formcomponents.FontType" value="DERIVED" />
+                      <property name="labelFontStyle" type="enum"
+                                class="com.install4j.runtime.beans.formcomponents.FontStyle" value="BOLD"/>
+                      <property name="labelFontType" type="enum"
+                                class="com.install4j.runtime.beans.formcomponents.FontType" value="DERIVED"/>
                     </serializedBean>
                   </formComponent>
-                  <formComponent name="Subtitle" id="51" beanClass="com.install4j.runtime.beans.styles.ScreenTitleComponent" insetLeft="8">
+                  <formComponent name="Subtitle" id="51"
+                                 beanClass="com.install4j.runtime.beans.styles.ScreenTitleComponent" insetLeft="8">
                     <serializedBean>
-                      <property name="titleType" type="enum" class="com.install4j.runtime.beans.styles.TitleType" value="SUB_TITLE" />
+                      <property name="titleType" type="enum" class="com.install4j.runtime.beans.styles.TitleType"
+                                value="SUB_TITLE"/>
                     </serializedBean>
                   </formComponent>
                 </beans>
@@ -939,14 +1093,14 @@ return true;</property>
           </style>
           <style name="Standard footer" id="52" beanClass="com.install4j.runtime.beans.styles.FormStyle">
             <serializedBean>
-              <property name="fillVertical" type="boolean" value="false" />
-              <property name="standalone" type="boolean" value="false" />
-              <property name="verticalAnchor" type="enum" class="com.install4j.api.beans.Anchor" value="SOUTH" />
+              <property name="fillVertical" type="boolean" value="false"/>
+              <property name="standalone" type="boolean" value="false"/>
+              <property name="verticalAnchor" type="enum" class="com.install4j.api.beans.Anchor" value="SOUTH"/>
             </serializedBean>
             <formComponents>
               <group id="53" beanClass="com.install4j.runtime.beans.groups.HorizontalFormComponentGroup">
                 <serializedBean>
-                  <property name="alignFirstLabel" type="boolean" value="false" />
+                  <property name="alignFirstLabel" type="boolean" value="false"/>
                   <property name="insets">
                     <object class="java.awt.Insets">
                       <int>3</int>
@@ -957,23 +1111,30 @@ return true;</property>
                   </property>
                 </serializedBean>
                 <beans>
-                  <formComponent id="54" beanClass="com.install4j.runtime.beans.formcomponents.SpringComponent" />
-                  <formComponent name="Back button" id="55" beanClass="com.install4j.runtime.beans.styles.StandardControlButtonComponent">
+                  <formComponent id="54" beanClass="com.install4j.runtime.beans.formcomponents.SpringComponent"/>
+                  <formComponent name="Back button" id="55"
+                                 beanClass="com.install4j.runtime.beans.styles.StandardControlButtonComponent">
                     <serializedBean>
                       <property name="buttonText" type="string">&lt; ${i18n:ButtonBack}</property>
-                      <property name="controlButtonType" type="enum" class="com.install4j.api.context.ControlButtonType" value="PREVIOUS" />
+                      <property name="controlButtonType" type="enum" class="com.install4j.api.context.ControlButtonType"
+                                value="PREVIOUS"/>
                     </serializedBean>
                   </formComponent>
-                  <formComponent name="Next button" id="56" beanClass="com.install4j.runtime.beans.styles.StandardControlButtonComponent">
+                  <formComponent name="Next button" id="56"
+                                 beanClass="com.install4j.runtime.beans.styles.StandardControlButtonComponent">
                     <serializedBean>
                       <property name="buttonText" type="string">${i18n:ButtonNext} &gt;</property>
-                      <property name="controlButtonType" type="enum" class="com.install4j.api.context.ControlButtonType" value="NEXT" />
+                      <property name="controlButtonType" type="enum" class="com.install4j.api.context.ControlButtonType"
+                                value="NEXT"/>
                     </serializedBean>
                   </formComponent>
-                  <formComponent name="Cancel button" id="57" beanClass="com.install4j.runtime.beans.styles.StandardControlButtonComponent" insetLeft="5">
+                  <formComponent name="Cancel button" id="57"
+                                 beanClass="com.install4j.runtime.beans.styles.StandardControlButtonComponent"
+                                 insetLeft="5">
                     <serializedBean>
                       <property name="buttonText" type="string">${i18n:ButtonCancel}</property>
-                      <property name="controlButtonType" type="enum" class="com.install4j.api.context.ControlButtonType" value="CANCEL" />
+                      <property name="controlButtonType" type="enum" class="com.install4j.api.context.ControlButtonType"
+                                value="CANCEL"/>
                     </serializedBean>
                   </formComponent>
                 </beans>
@@ -985,19 +1146,22 @@ return true;</property>
     </styles>
   </installerGui>
   <mediaSets>
-    <unixInstaller name="Unix Installer ARM32" id="161" mediaFileName="${compiler:sys.shortName}_${compiler:sys.platform}-armhf_${compiler:sys.version}">
-      <jreBundle jdkProviderId="Liberica" release="OpenJDK 14.0.1+8" overrideJdkRelease="true" jreBundleSource="generated" platform="linux-arm32-vfp-hflt">
+    <windows name="Windows 32" id="63"
+             mediaFileName="${compiler:sys.shortName}_${compiler:sys.platform}_${compiler:sys.version}" jreBitType="32">
+      <jreBundle usePack200="false" jreBundleSource="generated">
         <modules>
-          <defaultModules set="all" />
+          <defaultModules set="all"/>
         </modules>
       </jreBundle>
-    </unixInstaller>
-    <linuxDeb name="Linux Deb Archive ARM32" id="164" mediaFileName="${compiler:sys.shortName}_${compiler:sys.platform}-armhf_${compiler:sys.version}" maintainerEmail="info@mediathekview.de" architectureSet="true" architecture="armhf">
-      <jreBundle jdkProviderId="Liberica" release="OpenJDK 14.0.1+8" overrideJdkRelease="true" jreBundleSource="generated" platform="linux-arm32-vfp-hflt">
+    </windows>
+    <windowsArchive name="Windows Archive" id="65"
+                    mediaFileName="${compiler:sys.shortName}_${compiler:sys.platform}_${compiler:sys.version}"
+                    jreBitType="32">
+      <jreBundle jdkProviderId="Liberica" jreBundleSource="generated">
         <modules>
-          <defaultModules set="all" />
+          <defaultModules set="all"/>
         </modules>
       </jreBundle>
-    </linuxDeb>
+    </windowsArchive>
   </mediaSets>
 </install4j>

--- a/.install4j/mediathekview_windows32.install4j
+++ b/.install4j/mediathekview_windows32.install4j
@@ -38,7 +38,7 @@
     <launcher name="mediathekview" id="59" menuName="MediathekView">
       <executable name="MediathekView" iconSet="true" executableMode="gui" singleInstance="true"/>
       <java mainClass="mediathek.Main"
-            vmParameters="-Xmx2G -DexternalUpdateCheck --add-exports=javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED">
+            vmParameters="-Xmx1G -DexternalUpdateCheck --add-exports=javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED">
         <classPath>
           <archive location="MediathekView.jar" failOnError="false"/>
         </classPath>
@@ -53,7 +53,7 @@
     <launcher name="MediathekView_ipv4" id="60" menuName="MediathekView IPv4">
       <executable name="MediathekView_ipv4" iconSet="true" executableMode="gui" singleInstance="true"/>
       <java mainClass="mediathek.Main"
-            vmParameters="-Xmx2G -DexternalUpdateCheck --add-exports=javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED -Djava.net.preferIPv4Stack=true">
+            vmParameters="-Xmx1G -DexternalUpdateCheck --add-exports=javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED -Djava.net.preferIPv4Stack=true">
         <classPath>
           <archive location="MediathekView.jar" failOnError="false"/>
         </classPath>
@@ -68,7 +68,7 @@
     <launcher name="MediathekView_Portable" id="61" excludeFromMenu="true">
       <executable name="MediathekView_Portable" iconSet="true" executableMode="gui"/>
       <java mainClass="mediathek.Main"
-            vmParameters="-Xmx2G -DexternalUpdateCheck --add-exports=javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED"
+            vmParameters="-Xmx1G -DexternalUpdateCheck --add-exports=javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED"
             arguments="Einstellungen/.mediathek3">
         <classPath>
           <archive location="MediathekView.jar" failOnError="false"/>

--- a/.install4j/mediathekview_windows32.install4j
+++ b/.install4j/mediathekview_windows32.install4j
@@ -1,105 +1,92 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <install4j version="8.0.7" transformSequenceNumber="8">
-  <directoryPresets config="${project.build.directory}/res"/>
-  <application name="MediathekView" applicationId="1927-5045-2127-3394" mediaDir="target" shortName="MediathekView"
-               publisher="MediathekView Team" publisherWeb="https://mediathekview.de" version="${project.version}"
-               macVolumeId="d594baf3c2b3424d" javaMinVersion="13">
+  <directoryPresets config="/home/nicklas/git/MediathekView" />
+  <application name="MediathekView" applicationId="1927-5045-2127-3394" mediaDir="target" shortName="MediathekView" publisher="MediathekView Team" publisherWeb="https://mediathekview.de" version="${project.version}" macVolumeId="d594baf3c2b3424d" javaMinVersion="13">
     <languages>
-      <principalLanguage id="de"/>
+      <principalLanguage id="de" />
     </languages>
     <jreBundles jdkProviderId="Liberica" release="OpenJDK 14.0.1+8">
       <modules>
-        <defaultModules set="all"/>
+        <defaultModules set="all" />
       </modules>
     </jreBundles>
   </application>
   <files>
     <mountPoints>
-      <mountPoint id="58"/>
+      <mountPoint id="58" />
     </mountPoints>
     <entries>
-      <fileEntry mountPoint="58" file="${project.build.directory}/MediathekView.jar" overwriteMode="1" uninstallMode="2"
-                 overrideOverwriteMode="true" overrideUninstallMode="true"/>
-      <fileEntry mountPoint="58" file="${project.build.directory}/res/MediathekView.ico" overwriteMode="1"
-                 uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true"/>
-      <fileEntry mountPoint="58" file="${project.build.directory}/res/MediathekView.svg" overwriteMode="1"
-                 uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true"/>
-      <dirEntry mountPoint="58" file="${project.build.directory}/res/bin" overwriteMode="1" uninstallMode="2"
-                overrideOverwriteMode="true" overrideUninstallMode="true" entryMode="subdir" subDirectory="bin">
+      <fileEntry mountPoint="58" file="${project.build.directory}/MediathekView.jar" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" />
+      <fileEntry mountPoint="58" file="${project.build.directory}/res/MediathekView.ico" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" />
+      <fileEntry mountPoint="58" file="${project.build.directory}/res/MediathekView.svg" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" />
+      <dirEntry mountPoint="58" file="${project.build.directory}/res/bin" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" entryMode="subdir" subDirectory="bin">
         <exclude>
-          <entry location="aria2-remote.sh"/>
+          <entry location="ffmpeg.exe" />
+          <entry location="aria2-remote.sh" />
+          <entry location="ffmpeg.txt" />
         </exclude>
       </dirEntry>
-      <fileEntry mountPoint="58" file="${project.build.directory}/res/README.txt" overwriteMode="1" uninstallMode="2"
-                 overrideOverwriteMode="true" overrideUninstallMode="true"/>
+      <fileEntry mountPoint="58" file="${project.build.directory}/res/README.txt" overwriteMode="1" uninstallMode="2" overrideOverwriteMode="true" overrideUninstallMode="true" />
     </entries>
   </files>
   <launchers>
     <launcher name="mediathekview" id="59" menuName="MediathekView">
-      <executable name="MediathekView" iconSet="true" executableMode="gui" singleInstance="true"/>
-      <java mainClass="mediathek.Main"
-            vmParameters="-Xmx1G -DexternalUpdateCheck --add-exports=javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED">
+      <executable name="MediathekView" iconSet="true" executableMode="gui" singleInstance="true" />
+      <java mainClass="mediathek.Main" vmParameters="-Xmx1280M -DexternalUpdateCheck --add-exports=javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED">
         <classPath>
-          <archive location="MediathekView.jar" failOnError="false"/>
+          <archive location="MediathekView.jar" failOnError="false" />
         </classPath>
       </java>
       <iconImageFiles>
-        <file path="${project.basedir}/.install4j/MediathekView@x16.png"/>
-        <file path="${project.basedir}/.install4j/MediathekView@x32.png"/>
-        <file path="${project.basedir}/.install4j/MediathekView@x48.png"/>
-        <file path="${project.basedir}/.install4j/MediathekView@x128.png"/>
+        <file path="${project.basedir}/.install4j/MediathekView@x16.png" />
+        <file path="${project.basedir}/.install4j/MediathekView@x32.png" />
+        <file path="${project.basedir}/.install4j/MediathekView@x48.png" />
+        <file path="${project.basedir}/.install4j/MediathekView@x128.png" />
       </iconImageFiles>
     </launcher>
     <launcher name="MediathekView_ipv4" id="60" menuName="MediathekView IPv4">
-      <executable name="MediathekView_ipv4" iconSet="true" executableMode="gui" singleInstance="true"/>
-      <java mainClass="mediathek.Main"
-            vmParameters="-Xmx1G -DexternalUpdateCheck --add-exports=javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED -Djava.net.preferIPv4Stack=true">
+      <executable name="MediathekView_ipv4" iconSet="true" executableMode="gui" singleInstance="true" />
+      <java mainClass="mediathek.Main" vmParameters="-Xmx1280M -DexternalUpdateCheck --add-exports=javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED -Djava.net.preferIPv4Stack=true">
         <classPath>
-          <archive location="MediathekView.jar" failOnError="false"/>
+          <archive location="MediathekView.jar" failOnError="false" />
         </classPath>
       </java>
       <iconImageFiles>
-        <file path="${project.basedir}/.install4j/MediathekView@x16.png"/>
-        <file path="${project.basedir}/.install4j/MediathekView@x32.png"/>
-        <file path="${project.basedir}/.install4j/MediathekView@x48.png"/>
-        <file path="${project.basedir}/.install4j/MediathekView@x128.png"/>
+        <file path="${project.basedir}/.install4j/MediathekView@x16.png" />
+        <file path="${project.basedir}/.install4j/MediathekView@x32.png" />
+        <file path="${project.basedir}/.install4j/MediathekView@x48.png" />
+        <file path="${project.basedir}/.install4j/MediathekView@x128.png" />
       </iconImageFiles>
     </launcher>
     <launcher name="MediathekView_Portable" id="61" excludeFromMenu="true">
-      <executable name="MediathekView_Portable" iconSet="true" executableMode="gui"/>
-      <java mainClass="mediathek.Main"
-            vmParameters="-Xmx1G -DexternalUpdateCheck --add-exports=javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED"
-            arguments="Einstellungen/.mediathek3">
+      <executable name="MediathekView_Portable" iconSet="true" executableMode="gui" />
+      <java mainClass="mediathek.Main" vmParameters="-Xmx1280M -DexternalUpdateCheck --add-exports=javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED" arguments="Einstellungen/.mediathek3">
         <classPath>
-          <archive location="MediathekView.jar" failOnError="false"/>
+          <archive location="MediathekView.jar" failOnError="false" />
         </classPath>
       </java>
       <iconImageFiles>
-        <file path="${project.basedir}/.install4j/MediathekView@x16.png"/>
-        <file path="${project.basedir}/.install4j/MediathekView@x32.png"/>
-        <file path="${project.basedir}/.install4j/MediathekView@x48.png"/>
-        <file path="${project.basedir}/.install4j/MediathekView@x128.png"/>
+        <file path="${project.basedir}/.install4j/MediathekView@x16.png" />
+        <file path="${project.basedir}/.install4j/MediathekView@x32.png" />
+        <file path="${project.basedir}/.install4j/MediathekView@x48.png" />
+        <file path="${project.basedir}/.install4j/MediathekView@x128.png" />
       </iconImageFiles>
     </launcher>
   </launchers>
-  <installerGui autoUpdateDescriptorUrl="https://mediathekview.de/downloads/update.xml" useAutoUpdateBaseUrl="true"
-                autoUpdateBaseUrl="https://download.mediathekview.de/stabil/">
+  <installerGui autoUpdateDescriptorUrl="https://mediathekview.de/downloads/update.xml" useAutoUpdateBaseUrl="true" autoUpdateBaseUrl="https://download.mediathekview.de/stabil/">
     <applications>
       <application id="installer" beanClass="com.install4j.runtime.beans.applications.InstallerApplication">
         <startup>
           <screen id="1" beanClass="com.install4j.runtime.beans.screens.StartupScreen" rollbackBarrierExitCode="0">
             <actions>
-              <action id="22" beanClass="com.install4j.runtime.beans.actions.misc.RequestPrivilegesAction"
-                      actionElevationType="none" rollbackBarrierExitCode="0"/>
+              <action id="22" beanClass="com.install4j.runtime.beans.actions.misc.RequestPrivilegesAction" actionElevationType="none" rollbackBarrierExitCode="0" />
             </actions>
           </screen>
         </startup>
         <screens>
-          <screen id="2" beanClass="com.install4j.runtime.beans.screens.WelcomeScreen" styleId="41"
-                  rollbackBarrierExitCode="0">
+          <screen id="2" beanClass="com.install4j.runtime.beans.screens.WelcomeScreen" styleId="41" rollbackBarrierExitCode="0">
             <actions>
-              <action id="7" beanClass="com.install4j.runtime.beans.actions.misc.LoadResponseFileAction"
-                      rollbackBarrierExitCode="0" multiExec="true">
+              <action id="7" beanClass="com.install4j.runtime.beans.actions.misc.LoadResponseFileAction" rollbackBarrierExitCode="0" multiExec="true">
                 <serializedBean>
                   <property name="excludedVariables" type="array" elementType="string" length="1">
                     <element index="0">sys.installationDir</element>
@@ -127,27 +114,22 @@
                   </property>
                 </serializedBean>
               </formComponent>
-              <formComponent id="5" beanClass="com.install4j.runtime.beans.formcomponents.UpdateAlertComponent"
-                             useExternalParametrization="true" externalParametrizationName="Update Alert"
-                             externalParametrizationMode="include">
+              <formComponent id="5" beanClass="com.install4j.runtime.beans.formcomponents.UpdateAlertComponent" useExternalParametrization="true" externalParametrizationName="Update Alert" externalParametrizationMode="include">
                 <externalParametrizationPropertyNames>
                   <propertyName>updateCheck</propertyName>
                 </externalParametrizationPropertyNames>
               </formComponent>
-              <formComponent id="6" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent"
-                             insetTop="20">
+              <formComponent id="6" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent" insetTop="20">
                 <serializedBean>
                   <property name="labelText" type="string">${i18n:ClickNext}</property>
                 </serializedBean>
               </formComponent>
             </formComponents>
           </screen>
-          <screen id="8" beanClass="com.install4j.runtime.beans.screens.InstallationDirectoryScreen"
-                  rollbackBarrierExitCode="0">
+          <screen id="8" beanClass="com.install4j.runtime.beans.screens.InstallationDirectoryScreen" rollbackBarrierExitCode="0">
             <condition>!context.getBooleanVariable("sys.confirmedUpdateInstallation")</condition>
             <actions>
-              <action id="11" beanClass="com.install4j.runtime.beans.actions.misc.LoadResponseFileAction"
-                      rollbackBarrierExitCode="0" multiExec="true">
+              <action id="11" beanClass="com.install4j.runtime.beans.actions.misc.LoadResponseFileAction" rollbackBarrierExitCode="0" multiExec="true">
                 <serializedBean>
                   <property name="excludedVariables" type="array" elementType="string" length="1">
                     <element index="0">sys.installationDir</element>
@@ -157,19 +139,14 @@
               </action>
             </actions>
             <formComponents>
-              <formComponent id="9" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent"
-                             insetBottom="25">
+              <formComponent id="9" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent" insetBottom="25">
                 <serializedBean>
                   <property name="labelText" type="string">${i18n:SelectDirLabel(${compiler:sys.fullName})}</property>
                 </serializedBean>
               </formComponent>
-              <formComponent id="10"
-                             beanClass="com.install4j.runtime.beans.formcomponents.InstallationDirectoryChooserComponent"
-                             useExternalParametrization="true"
-                             externalParametrizationName="Installation Directory Chooser"
-                             externalParametrizationMode="include">
+              <formComponent id="10" beanClass="com.install4j.runtime.beans.formcomponents.InstallationDirectoryChooserComponent" useExternalParametrization="true" externalParametrizationName="Installation Directory Chooser" externalParametrizationMode="include">
                 <serializedBean>
-                  <property name="requestFocus" type="boolean" value="true"/>
+                  <property name="requestFocus" type="boolean" value="true" />
                 </serializedBean>
                 <externalParametrizationPropertyNames>
                   <propertyName>suggestAppDir</propertyName>
@@ -187,14 +164,10 @@
               </formComponent>
             </formComponents>
           </screen>
-          <screen id="15" beanClass="com.install4j.runtime.beans.screens.InstallationScreen" rollbackBarrier="true"
-                  rollbackBarrierExitCode="0">
+          <screen id="15" beanClass="com.install4j.runtime.beans.screens.InstallationScreen" rollbackBarrier="true" rollbackBarrierExitCode="0">
             <actions>
-              <action id="17" beanClass="com.install4j.runtime.beans.actions.InstallFilesAction"
-                      actionElevationType="elevated" rollbackBarrierExitCode="0" failureStrategy="quit"
-                      errorMessage="${i18n:FileCorrupted}"/>
-              <action id="18" beanClass="com.install4j.runtime.beans.actions.desktop.CreateProgramGroupAction"
-                      actionElevationType="elevated" rollbackBarrierExitCode="0">
+              <action id="17" beanClass="com.install4j.runtime.beans.actions.InstallFilesAction" actionElevationType="elevated" rollbackBarrierExitCode="0" failureStrategy="quit" errorMessage="${i18n:FileCorrupted}" />
+              <action id="18" beanClass="com.install4j.runtime.beans.actions.desktop.CreateProgramGroupAction" actionElevationType="elevated" rollbackBarrierExitCode="0">
                 <serializedBean>
                   <property name="uninstallerMenuName" type="string">
                     ${i18n:UninstallerMenuEntry(${compiler:sys.fullName})}
@@ -202,8 +175,7 @@
                 </serializedBean>
                 <condition>!context.getBooleanVariable("sys.programGroupDisabled")</condition>
               </action>
-              <action id="19" beanClass="com.install4j.runtime.beans.actions.desktop.RegisterAddRemoveAction"
-                      actionElevationType="elevated" rollbackBarrierExitCode="0">
+              <action id="19" beanClass="com.install4j.runtime.beans.actions.desktop.RegisterAddRemoveAction" actionElevationType="elevated" rollbackBarrierExitCode="0">
                 <serializedBean>
                   <property name="itemName" type="string">${compiler:sys.fullName} ${compiler:sys.version}</property>
                 </serializedBean>
@@ -217,11 +189,9 @@
               </formComponent>
             </formComponents>
           </screen>
-          <screen id="20" beanClass="com.install4j.runtime.beans.screens.FinishedScreen" styleId="41"
-                  rollbackBarrierExitCode="0" finishScreen="true">
+          <screen id="20" beanClass="com.install4j.runtime.beans.screens.FinishedScreen" styleId="41" rollbackBarrierExitCode="0" finishScreen="true">
             <formComponents>
-              <formComponent id="21" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent"
-                             insetBottom="10">
+              <formComponent id="21" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent" insetBottom="10">
                 <serializedBean>
                   <property name="labelText" type="string">${form:finishedMessage}</property>
                 </serializedBean>
@@ -235,24 +205,20 @@
           <property name="customMacosExecutableName" type="string">
             ${i18n:UninstallerMenuEntry(${compiler:sys.fullName})}
           </property>
-          <property name="useCustomMacosExecutableName" type="boolean" value="true"/>
+          <property name="useCustomMacosExecutableName" type="boolean" value="true" />
         </serializedBean>
         <startup>
           <screen id="23" beanClass="com.install4j.runtime.beans.screens.StartupScreen" rollbackBarrierExitCode="0">
             <actions>
-              <action id="33" beanClass="com.install4j.runtime.beans.actions.misc.LoadResponseFileAction"
-                      rollbackBarrierExitCode="0"/>
-              <action id="34" beanClass="com.install4j.runtime.beans.actions.misc.RequireInstallerPrivilegesAction"
-                      actionElevationType="none" rollbackBarrierExitCode="0"/>
+              <action id="33" beanClass="com.install4j.runtime.beans.actions.misc.LoadResponseFileAction" rollbackBarrierExitCode="0" />
+              <action id="34" beanClass="com.install4j.runtime.beans.actions.misc.RequireInstallerPrivilegesAction" actionElevationType="none" rollbackBarrierExitCode="0" />
             </actions>
           </screen>
         </startup>
         <screens>
-          <screen id="24" beanClass="com.install4j.runtime.beans.screens.UninstallWelcomeScreen" styleId="41"
-                  rollbackBarrierExitCode="0">
+          <screen id="24" beanClass="com.install4j.runtime.beans.screens.UninstallWelcomeScreen" styleId="41" rollbackBarrierExitCode="0">
             <formComponents>
-              <formComponent id="25" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent"
-                             insetBottom="10">
+              <formComponent id="25" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent" insetBottom="10">
                 <serializedBean>
                   <property name="labelText" type="string">${form:welcomeMessage}</property>
                 </serializedBean>
@@ -272,11 +238,9 @@
               </formComponent>
             </formComponents>
           </screen>
-          <screen id="27" beanClass="com.install4j.runtime.beans.screens.UninstallationScreen"
-                  rollbackBarrierExitCode="0">
+          <screen id="27" beanClass="com.install4j.runtime.beans.screens.UninstallationScreen" rollbackBarrierExitCode="0">
             <actions>
-              <action id="29" beanClass="com.install4j.runtime.beans.actions.UninstallFilesAction"
-                      actionElevationType="elevated" rollbackBarrierExitCode="0"/>
+              <action id="29" beanClass="com.install4j.runtime.beans.actions.UninstallFilesAction" actionElevationType="elevated" rollbackBarrierExitCode="0" />
             </actions>
             <formComponents>
               <formComponent id="28" beanClass="com.install4j.runtime.beans.formcomponents.ProgressComponent">
@@ -286,13 +250,10 @@
               </formComponent>
             </formComponents>
           </screen>
-          <screen id="32" beanClass="com.install4j.runtime.beans.screens.UninstallFailureScreen"
-                  rollbackBarrierExitCode="0" finishScreen="true"/>
-          <screen id="30" beanClass="com.install4j.runtime.beans.screens.UninstallSuccessScreen" styleId="41"
-                  rollbackBarrierExitCode="0" finishScreen="true">
+          <screen id="32" beanClass="com.install4j.runtime.beans.screens.UninstallFailureScreen" rollbackBarrierExitCode="0" finishScreen="true" />
+          <screen id="30" beanClass="com.install4j.runtime.beans.screens.UninstallSuccessScreen" styleId="41" rollbackBarrierExitCode="0" finishScreen="true">
             <formComponents>
-              <formComponent id="31" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent"
-                             insetBottom="10">
+              <formComponent id="31" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent" insetBottom="10">
                 <serializedBean>
                   <property name="labelText" type="string">${form:successMessage}</property>
                 </serializedBean>
@@ -301,9 +262,7 @@
           </screen>
         </screens>
       </application>
-      <application name="Update downloader with silent version check" id="319"
-                   beanClass="com.install4j.runtime.beans.applications.CustomApplication"
-                   automaticLauncherIntegration="true" launchSchedule="always" allLaunchers="false">
+      <application name="Update downloader with silent version check" id="319" beanClass="com.install4j.runtime.beans.applications.CustomApplication" automaticLauncherIntegration="true" launchSchedule="always" allLaunchers="false">
         <serializedBean>
           <property name="customIconImageFiles">
             <add>
@@ -333,29 +292,27 @@
             </add>
           </property>
           <property name="executableName" type="string">update</property>
-          <property name="useCustomIcon" type="boolean" value="true"/>
+          <property name="useCustomIcon" type="boolean" value="true" />
           <property name="windowTitle" type="string">${i18n:updater.WindowTitle("${compiler:sys.fullName}")}</property>
         </serializedBean>
         <launcherIds>
-          <launcher id="59"/>
-          <launcher id="60"/>
-          <launcher id="61"/>
+          <launcher id="59" />
+          <launcher id="60" />
+          <launcher id="61" />
         </launcherIds>
         <startup>
           <screen id="320" beanClass="com.install4j.runtime.beans.screens.StartupScreen" rollbackBarrierExitCode="0">
             <actions>
-              <action id="363" beanClass="com.install4j.runtime.beans.actions.update.CheckForUpdateAction"
-                      actionElevationType="none" failureStrategy="quit">
+              <action id="363" beanClass="com.install4j.runtime.beans.actions.update.CheckForUpdateAction" actionElevationType="none" failureStrategy="quit">
                 <serializedBean>
-                  <property name="showError" type="boolean" value="false"/>
+                  <property name="showError" type="boolean" value="false" />
                   <property name="url" type="string">${installer:updatesUrl?:${compiler:sys.updatesUrl}}</property>
                   <property name="variable" type="string">updateDescriptor</property>
                 </serializedBean>
               </action>
-              <action name="Update descriptor entry" id="364"
-                      beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction" failureStrategy="quit">
+              <action name="Update descriptor entry" id="364" beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction" failureStrategy="quit">
                 <serializedBean>
-                  <property name="failIfNull" type="boolean" value="true"/>
+                  <property name="failIfNull" type="boolean" value="true" />
                   <property name="script">
                     <object class="com.install4j.api.beans.ScriptProperty">
                       <property name="value" type="string">
@@ -376,8 +333,7 @@
                   </property>
                 </serializedBean>
                 <beans>
-                  <action name="New version" id="366"
-                          beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
+                  <action name="New version" id="366" beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
                     <serializedBean>
                       <property name="script">
                         <object class="com.install4j.api.beans.ScriptProperty">
@@ -389,8 +345,7 @@
                       <property name="variableName" type="string">updaterNewVersion</property>
                     </serializedBean>
                   </action>
-                  <action name="Download size" id="367"
-                          beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
+                  <action name="Download size" id="367" beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
                     <serializedBean>
                       <property name="script">
                         <object class="com.install4j.api.beans.ScriptProperty">
@@ -402,8 +357,7 @@
                       <property name="variableName" type="string">updaterDownloadSize</property>
                     </serializedBean>
                   </action>
-                  <action name="Comment" id="368"
-                          beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
+                  <action name="Comment" id="368" beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
                     <serializedBean>
                       <property name="script">
                         <object class="com.install4j.api.beans.ScriptProperty">
@@ -415,8 +369,7 @@
                       <property name="variableName" type="string">updaterComment</property>
                     </serializedBean>
                   </action>
-                  <action name="Download URL" id="369"
-                          beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
+                  <action name="Download URL" id="369" beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
                     <serializedBean>
                       <property name="script">
                         <object class="com.install4j.api.beans.ScriptProperty">
@@ -428,8 +381,7 @@
                       <property name="variableName" type="string">updaterDownloadUrl</property>
                     </serializedBean>
                   </action>
-                  <action name="Archive" id="370"
-                          beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
+                  <action name="Archive" id="370" beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
                     <serializedBean>
                       <property name="script">
                         <object class="com.install4j.api.beans.ScriptProperty">
@@ -488,17 +440,14 @@
                           <int>255</int>
                         </object>
                       </property>
-                      <property name="valueLabelFontStyle" type="enum"
-                                class="com.install4j.runtime.beans.formcomponents.FontStyle" value="BOLD"/>
-                      <property name="valueLabelFontType" type="enum"
-                                class="com.install4j.runtime.beans.formcomponents.FontType" value="DERIVED"/>
+                      <property name="valueLabelFontStyle" type="enum" class="com.install4j.runtime.beans.formcomponents.FontStyle" value="BOLD" />
+                      <property name="valueLabelFontType" type="enum" class="com.install4j.runtime.beans.formcomponents.FontType" value="DERIVED" />
                       <property name="valueLabelText" type="string">${installer:sys.version}</property>
                     </serializedBean>
                   </formComponent>
                   <group id="324" beanClass="com.install4j.runtime.beans.groups.HorizontalFormComponentGroup">
                     <beans>
-                      <formComponent id="325"
-                                     beanClass="com.install4j.runtime.beans.formcomponents.KeyValuePairComponent">
+                      <formComponent id="325" beanClass="com.install4j.runtime.beans.formcomponents.KeyValuePairComponent">
                         <serializedBean>
                           <property name="labelText" type="string">${i18n:updater.NewVersionLabel}</property>
                           <property name="valueLabelColor">
@@ -509,16 +458,12 @@
                               <int>255</int>
                             </object>
                           </property>
-                          <property name="valueLabelFontStyle" type="enum"
-                                    class="com.install4j.runtime.beans.formcomponents.FontStyle" value="BOLD"/>
-                          <property name="valueLabelFontType" type="enum"
-                                    class="com.install4j.runtime.beans.formcomponents.FontType" value="DERIVED"/>
+                          <property name="valueLabelFontStyle" type="enum" class="com.install4j.runtime.beans.formcomponents.FontStyle" value="BOLD" />
+                          <property name="valueLabelFontType" type="enum" class="com.install4j.runtime.beans.formcomponents.FontType" value="DERIVED" />
                           <property name="valueLabelText" type="string">${installer:updaterNewVersion}</property>
                         </serializedBean>
                       </formComponent>
-                      <formComponent id="326"
-                                     beanClass="com.install4j.runtime.beans.formcomponents.HyperlinkActionLabelComponent"
-                                     insetLeft="5">
+                      <formComponent id="326" beanClass="com.install4j.runtime.beans.formcomponents.HyperlinkActionLabelComponent" insetLeft="5">
                         <serializedBean>
                           <property name="actionScript">
                             <object class="com.install4j.api.beans.ScriptProperty">
@@ -532,19 +477,17 @@
                       </formComponent>
                     </beans>
                   </group>
-                  <formComponent id="327" beanClass="com.install4j.runtime.beans.formcomponents.SpacerComponent"/>
-                  <formComponent id="328"
-                                 beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent">
+                  <formComponent id="327" beanClass="com.install4j.runtime.beans.formcomponents.SpacerComponent" />
+                  <formComponent id="328" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent">
                     <serializedBean>
                       <property name="labelText" type="string">${i18n:updater.DownloadLocationLabel}</property>
                     </serializedBean>
                   </formComponent>
-                  <formComponent id="329"
-                                 beanClass="com.install4j.runtime.beans.formcomponents.DirectoryChooserComponent">
+                  <formComponent id="329" beanClass="com.install4j.runtime.beans.formcomponents.DirectoryChooserComponent">
                     <serializedBean>
                       <property name="initialFile" type="string">${installer:sys.downloadsDir}</property>
                       <property name="labelText" type="string">${i18n:updater.DownloadToLabel}</property>
-                      <property name="manualEntryAllowed" type="boolean" value="false"/>
+                      <property name="manualEntryAllowed" type="boolean" value="false" />
                       <property name="variableName" type="string">updaterDownloadLocation</property>
                     </serializedBean>
                   </formComponent>
@@ -558,7 +501,7 @@
               </screen>
               <screen name="Update message" id="331" beanClass="com.install4j.runtime.beans.screens.FormScreen">
                 <serializedBean>
-                  <property name="scrollable" type="boolean" value="false"/>
+                  <property name="scrollable" type="boolean" value="false" />
                   <property name="subTitle" type="string">${i18n:updater.CommentsSubTitle}</property>
                   <property name="title" type="string">${i18n:updater.CommentsTitle}</property>
                 </serializedBean>
@@ -574,11 +517,9 @@
                   wizardContext.setControlButtonVisible(ControlButtonType.CANCEL, false);
                 </postActivation>
                 <formComponents>
-                  <formComponent id="332" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent"
-                                 useExternalParametrization="true" externalParametrizationName="Header"
-                                 externalParametrizationMode="include">
+                  <formComponent id="332" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent" useExternalParametrization="true" externalParametrizationName="Header" externalParametrizationMode="include">
                     <serializedBean>
-                      <property name="hideIfBlank" type="boolean" value="true"/>
+                      <property name="hideIfBlank" type="boolean" value="true" />
                       <property name="labelText" type="string">${i18n:updater.CommentsLabel}</property>
                     </serializedBean>
                     <visibilityScript>!context.isConsole()</visibilityScript>
@@ -586,15 +527,11 @@
                       <propertyName>labelText</propertyName>
                     </externalParametrizationPropertyNames>
                   </formComponent>
-                  <formComponent id="333"
-                                 beanClass="com.install4j.runtime.beans.formcomponents.HtmlDisplayFormComponent"
-                                 useExternalParametrization="true" externalParametrizationName="HTML display"
-                                 externalParametrizationMode="include">
+                  <formComponent id="333" beanClass="com.install4j.runtime.beans.formcomponents.HtmlDisplayFormComponent" useExternalParametrization="true" externalParametrizationName="HTML display" externalParametrizationMode="include">
                     <serializedBean>
                       <property name="displayedText" type="string">${installer:updaterComment}</property>
-                      <property name="fillVertical" type="boolean" value="true"/>
-                      <property name="textSource" type="enum"
-                                class="com.install4j.runtime.beans.screens.components.TextSource" value="DIRECT"/>
+                      <property name="fillVertical" type="boolean" value="true" />
+                      <property name="textSource" type="enum" class="com.install4j.runtime.beans.screens.components.TextSource" value="DIRECT" />
                     </serializedBean>
                     <externalParametrizationPropertyNames>
                       <propertyName>textSource</propertyName>
@@ -603,8 +540,7 @@
                       <propertyName>variableName</propertyName>
                     </externalParametrizationPropertyNames>
                   </formComponent>
-                  <formComponent id="334"
-                                 beanClass="com.install4j.runtime.beans.formcomponents.ConsoleHandlerFormComponent">
+                  <formComponent id="334" beanClass="com.install4j.runtime.beans.formcomponents.ConsoleHandlerFormComponent">
                     <serializedBean>
                       <property name="consoleScript">
                         <object class="com.install4j.api.beans.ScriptProperty">
@@ -627,8 +563,7 @@
                   context.goForward(1, true, true);
                 </postActivation>
                 <actions>
-                  <action name="Download location" id="336"
-                          beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
+                  <action name="Download location" id="336" beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
                     <serializedBean>
                       <property name="script">
                         <object class="com.install4j.api.beans.ScriptProperty">
@@ -641,8 +576,7 @@
                       <property name="variableName" type="string">updaterDownloadFile</property>
                     </serializedBean>
                   </action>
-                  <action id="337" beanClass="com.install4j.runtime.beans.actions.net.DownloadFileAction"
-                          actionElevationType="elevated" failureStrategy="quit">
+                  <action id="337" beanClass="com.install4j.runtime.beans.actions.net.DownloadFileAction" actionElevationType="elevated" failureStrategy="quit">
                     <serializedBean>
                       <property name="targetFile">
                         <object class="java.io.File">
@@ -652,8 +586,7 @@
                       <property name="url" type="string">${installer:updaterDownloadUrl}</property>
                     </serializedBean>
                   </action>
-                  <action id="338" beanClass="com.install4j.runtime.beans.actions.files.SetModeAction"
-                          actionElevationType="elevated">
+                  <action id="338" beanClass="com.install4j.runtime.beans.actions.files.SetModeAction" actionElevationType="elevated">
                     <serializedBean>
                       <property name="files" type="array" class="java.io.File" length="1">
                         <element index="0">
@@ -667,9 +600,7 @@
                   </action>
                 </actions>
                 <formComponents>
-                  <formComponent id="339" beanClass="com.install4j.runtime.beans.formcomponents.ProgressComponent"
-                                 useExternalParametrization="true" externalParametrizationName="Directory"
-                                 externalParametrizationMode="include">
+                  <formComponent id="339" beanClass="com.install4j.runtime.beans.formcomponents.ProgressComponent" useExternalParametrization="true" externalParametrizationName="Directory" externalParametrizationMode="include">
                     <externalParametrizationPropertyNames>
                       <propertyName>statusVisible</propertyName>
                       <propertyName>initialStatusMessage</propertyName>
@@ -679,8 +610,7 @@
               </screen>
               <group name="Finish" id="340" beanClass="com.install4j.runtime.beans.groups.ScreenGroup">
                 <beans>
-                  <screen name="Finish" id="341" beanClass="com.install4j.runtime.beans.screens.FormScreen" styleId="41"
-                          finishScreen="true">
+                  <screen name="Finish" id="341" beanClass="com.install4j.runtime.beans.screens.FormScreen" styleId="41" finishScreen="true">
                     <serializedBean>
                       <property name="title" type="string">${i18n:updater.FinishTitle}</property>
                     </serializedBean>
@@ -688,8 +618,7 @@
                       context.getBooleanVariable("isDmg"))
                     </condition>
                     <actions>
-                      <group name="Execute installer" id="342"
-                             beanClass="com.install4j.runtime.beans.groups.ActionGroup">
+                      <group name="Execute installer" id="342" beanClass="com.install4j.runtime.beans.groups.ActionGroup">
                         <serializedBean>
                           <property name="conditionExpression">
                             <object class="com.install4j.api.beans.ScriptProperty">
@@ -700,8 +629,7 @@
                           </property>
                         </serializedBean>
                         <beans>
-                          <action name="Set installer arguments" id="343"
-                                  beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
+                          <action name="Set installer arguments" id="343" beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction">
                             <serializedBean>
                               <property name="script">
                                 <object class="com.install4j.api.beans.ScriptProperty">
@@ -730,12 +658,8 @@
                               <property name="variableName" type="string">installerArguments</property>
                             </serializedBean>
                           </action>
-                          <action id="344"
-                                  beanClass="com.install4j.runtime.beans.actions.update.ShutdownCallingLauncherAction"
-                                  actionElevationType="none"/>
-                          <action id="345" beanClass="com.install4j.runtime.beans.actions.misc.RunExecutableAction"
-                                  actionElevationType="elevated" failureStrategy="quit"
-                                  errorMessage="${i18n:updater.LaunchError}">
+                          <action id="344" beanClass="com.install4j.runtime.beans.actions.update.ShutdownCallingLauncherAction" actionElevationType="none" />
+                          <action id="345" beanClass="com.install4j.runtime.beans.actions.misc.RunExecutableAction" actionElevationType="elevated" failureStrategy="quit" errorMessage="${i18n:updater.LaunchError}">
                             <serializedBean>
                               <property name="arguments" type="array" elementType="string" length="1">
                                 <element index="0">${installer:installerArguments}</element>
@@ -756,24 +680,18 @@
                       </group>
                     </actions>
                     <formComponents>
-                      <formComponent id="346"
-                                     beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent"
-                                     insetBottom="20" useExternalParametrization="true"
-                                     externalParametrizationName="Header" externalParametrizationMode="include">
+                      <formComponent id="346" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent" insetBottom="20" useExternalParametrization="true" externalParametrizationName="Header" externalParametrizationMode="include">
                         <serializedBean>
-                          <property name="hideIfBlank" type="boolean" value="true"/>
+                          <property name="hideIfBlank" type="boolean" value="true" />
                         </serializedBean>
                         <visibilityScript>!context.isConsole()</visibilityScript>
                         <externalParametrizationPropertyNames>
                           <propertyName>labelText</propertyName>
                         </externalParametrizationPropertyNames>
                       </formComponent>
-                      <formComponent id="347"
-                                     beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent"
-                                     insetBottom="20" useExternalParametrization="true"
-                                     externalParametrizationName="Header" externalParametrizationMode="include">
+                      <formComponent id="347" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent" insetBottom="20" useExternalParametrization="true" externalParametrizationName="Header" externalParametrizationMode="include">
                         <serializedBean>
-                          <property name="hideIfBlank" type="boolean" value="true"/>
+                          <property name="hideIfBlank" type="boolean" value="true" />
                           <property name="labelText" type="string">
                             ${i18n:updater.FinishInfoText("${compiler:sys.fullName}")}
                           </property>
@@ -790,11 +708,10 @@
                       </formComponent>
                       <formComponent id="349" beanClass="com.install4j.runtime.beans.formcomponents.SpacerComponent">
                         <serializedBean>
-                          <property name="height" type="int" value="5"/>
+                          <property name="height" type="int" value="5" />
                         </serializedBean>
                       </formComponent>
-                      <formComponent id="350"
-                                     beanClass="com.install4j.runtime.beans.formcomponents.RadiobuttonsComponent">
+                      <formComponent id="350" beanClass="com.install4j.runtime.beans.formcomponents.RadiobuttonsComponent">
                         <serializedBean>
                           <property name="radioButtonLabels" type="array" elementType="string" length="2">
                             <element index="0">${i18n:updater.LaunchUpdaterLabel}</element>
@@ -804,8 +721,7 @@
                         </serializedBean>
                         <visibilityScript>!context.getBooleanVariable("isArchive")</visibilityScript>
                       </formComponent>
-                      <formComponent id="351"
-                                     beanClass="com.install4j.runtime.beans.formcomponents.HyperlinkActionLabelComponent">
+                      <formComponent id="351" beanClass="com.install4j.runtime.beans.formcomponents.HyperlinkActionLabelComponent">
                         <serializedBean>
                           <property name="actionScript">
                             <object class="com.install4j.api.beans.ScriptProperty">
@@ -821,22 +737,20 @@
                       </formComponent>
                       <formComponent id="352" beanClass="com.install4j.runtime.beans.formcomponents.ProgressComponent">
                         <serializedBean>
-                          <property name="detailVisible" type="boolean" value="false"/>
-                          <property name="hideInitially" type="boolean" value="true"/>
+                          <property name="detailVisible" type="boolean" value="false" />
+                          <property name="hideInitially" type="boolean" value="true" />
                         </serializedBean>
                       </formComponent>
                     </formComponents>
                   </screen>
-                  <screen name="Finish DMG Archive" id="353" beanClass="com.install4j.runtime.beans.screens.FormScreen"
-                          styleId="41" finishScreen="true">
+                  <screen name="Finish DMG Archive" id="353" beanClass="com.install4j.runtime.beans.screens.FormScreen" styleId="41" finishScreen="true">
                     <serializedBean>
                       <property name="title" type="string">${i18n:updater.FinishTitle}</property>
                     </serializedBean>
                     <condition>context.getBooleanVariable("isArchive") &amp;&amp; context.getBooleanVariable("isDmg")
                     </condition>
                     <actions>
-                      <group name="Execute installer" id="354"
-                             beanClass="com.install4j.runtime.beans.groups.ActionGroup">
+                      <group name="Execute installer" id="354" beanClass="com.install4j.runtime.beans.groups.ActionGroup">
                         <serializedBean>
                           <property name="conditionExpression">
                             <object class="com.install4j.api.beans.ScriptProperty">
@@ -846,11 +760,8 @@
                           </property>
                         </serializedBean>
                         <beans>
-                          <action id="355"
-                                  beanClass="com.install4j.runtime.beans.actions.update.ShutdownCallingLauncherAction"
-                                  actionElevationType="none"/>
-                          <action name="Open DMG" id="356"
-                                  beanClass="com.install4j.runtime.beans.actions.control.RunScriptAction">
+                          <action id="355" beanClass="com.install4j.runtime.beans.actions.update.ShutdownCallingLauncherAction" actionElevationType="none" />
+                          <action name="Open DMG" id="356" beanClass="com.install4j.runtime.beans.actions.control.RunScriptAction">
                             <serializedBean>
                               <property name="script">
                                 <object class="com.install4j.api.beans.ScriptProperty">
@@ -866,24 +777,18 @@
                       </group>
                     </actions>
                     <formComponents>
-                      <formComponent id="357"
-                                     beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent"
-                                     insetBottom="20" useExternalParametrization="true"
-                                     externalParametrizationName="Header" externalParametrizationMode="include">
+                      <formComponent id="357" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent" insetBottom="20" useExternalParametrization="true" externalParametrizationName="Header" externalParametrizationMode="include">
                         <serializedBean>
-                          <property name="hideIfBlank" type="boolean" value="true"/>
+                          <property name="hideIfBlank" type="boolean" value="true" />
                         </serializedBean>
                         <visibilityScript>!context.isConsole()</visibilityScript>
                         <externalParametrizationPropertyNames>
                           <propertyName>labelText</propertyName>
                         </externalParametrizationPropertyNames>
                       </formComponent>
-                      <formComponent id="358"
-                                     beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent"
-                                     insetBottom="20" useExternalParametrization="true"
-                                     externalParametrizationName="Header" externalParametrizationMode="include">
+                      <formComponent id="358" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent" insetBottom="20" useExternalParametrization="true" externalParametrizationName="Header" externalParametrizationMode="include">
                         <serializedBean>
-                          <property name="hideIfBlank" type="boolean" value="true"/>
+                          <property name="hideIfBlank" type="boolean" value="true" />
                           <property name="labelText" type="string">
                             ${i18n:updater.FinishInfoText("${compiler:sys.fullName}")}
                           </property>
@@ -900,21 +805,21 @@
                       </formComponent>
                       <formComponent id="360" beanClass="com.install4j.runtime.beans.formcomponents.SpacerComponent">
                         <serializedBean>
-                          <property name="height" type="int" value="5"/>
+                          <property name="height" type="int" value="5" />
                         </serializedBean>
                       </formComponent>
                       <formComponent id="361" beanClass="com.install4j.runtime.beans.formcomponents.CheckboxComponent">
                         <serializedBean>
                           <property name="checkboxText" type="string">${i18n:updater.OpenContainingFolderLabel}
                           </property>
-                          <property name="initiallySelected" type="boolean" value="true"/>
+                          <property name="initiallySelected" type="boolean" value="true" />
                           <property name="variableName" type="string">updaterOpenDmg</property>
                         </serializedBean>
                       </formComponent>
                       <formComponent id="362" beanClass="com.install4j.runtime.beans.formcomponents.ProgressComponent">
                         <serializedBean>
-                          <property name="detailVisible" type="boolean" value="false"/>
-                          <property name="hideInitially" type="boolean" value="true"/>
+                          <property name="detailVisible" type="boolean" value="false" />
+                          <property name="hideInitially" type="boolean" value="true" />
                         </serializedBean>
                       </formComponent>
                     </formComponents>
@@ -929,30 +834,24 @@
     <styles defaultStyleId="35">
       <style name="Standard" id="35" beanClass="com.install4j.runtime.beans.styles.FormStyle">
         <formComponents>
-          <formComponent name="Header" id="36" beanClass="com.install4j.runtime.beans.styles.NestedStyleComponent"
-                         insetTop="0" insetBottom="0">
+          <formComponent name="Header" id="36" beanClass="com.install4j.runtime.beans.styles.NestedStyleComponent" insetTop="0" insetBottom="0">
             <serializedBean>
               <property name="styleId" type="string">48</property>
             </serializedBean>
           </formComponent>
           <group name="Main" id="37" beanClass="com.install4j.runtime.beans.groups.VerticalFormComponentGroup">
             <beans>
-              <formComponent id="38" beanClass="com.install4j.runtime.beans.styles.ContentComponent" insetTop="10"
-                             insetLeft="20" insetBottom="10" insetRight="20"/>
-              <formComponent name="Watermark" id="39"
-                             beanClass="com.install4j.runtime.beans.formcomponents.SeparatorComponent" insetTop="0"
-                             insetLeft="5" insetBottom="0" useExternalParametrization="true"
-                             externalParametrizationName="Custom watermark" externalParametrizationMode="include">
+              <formComponent id="38" beanClass="com.install4j.runtime.beans.styles.ContentComponent" insetTop="10" insetLeft="20" insetBottom="10" insetRight="20" />
+              <formComponent name="Watermark" id="39" beanClass="com.install4j.runtime.beans.formcomponents.SeparatorComponent" insetTop="0" insetLeft="5" insetBottom="0" useExternalParametrization="true" externalParametrizationName="Custom watermark" externalParametrizationMode="include">
                 <serializedBean>
-                  <property name="enabledTitleText" type="boolean" value="false"/>
+                  <property name="enabledTitleText" type="boolean" value="false" />
                   <property name="labelText" type="string">install4j</property>
                 </serializedBean>
                 <externalParametrizationPropertyNames>
                   <propertyName>labelText</propertyName>
                 </externalParametrizationPropertyNames>
               </formComponent>
-              <formComponent name="Footer" id="40" beanClass="com.install4j.runtime.beans.styles.NestedStyleComponent"
-                             insetTop="0" insetBottom="0">
+              <formComponent name="Footer" id="40" beanClass="com.install4j.runtime.beans.styles.NestedStyleComponent" insetTop="0" insetBottom="0">
                 <serializedBean>
                   <property name="styleId" type="string">52</property>
                 </serializedBean>
@@ -963,9 +862,7 @@
       </style>
       <style name="Banner" id="41" beanClass="com.install4j.runtime.beans.styles.FormStyle">
         <formComponents>
-          <group id="42" beanClass="com.install4j.runtime.beans.groups.VerticalFormComponentGroup"
-                 useExternalParametrization="true" externalParametrizationName="Customize banner image"
-                 externalParametrizationMode="include">
+          <group id="42" beanClass="com.install4j.runtime.beans.groups.VerticalFormComponentGroup" useExternalParametrization="true" externalParametrizationName="Customize banner image" externalParametrizationMode="include">
             <serializedBean>
               <property name="backgroundColor">
                 <object class="java.awt.Color">
@@ -977,7 +874,7 @@
               </property>
               <property name="borderSides">
                 <object class="com.install4j.runtime.beans.formcomponents.BorderSides">
-                  <property name="bottom" type="boolean" value="true"/>
+                  <property name="bottom" type="boolean" value="true" />
                 </object>
               </property>
               <property name="imageEdgeBackgroundColor">
@@ -988,7 +885,7 @@
                   <int>255</int>
                 </object>
               </property>
-              <property name="imageEdgeBorder" type="boolean" value="true"/>
+              <property name="imageEdgeBorder" type="boolean" value="true" />
               <property name="imageFile">
                 <object class="com.install4j.api.beans.ExternalFile">
                   <string>${compiler:sys.install4jHome}/resource/styles/wizard.png</string>
@@ -1006,16 +903,13 @@
             <beans>
               <formComponent id="43" beanClass="com.install4j.runtime.beans.styles.ScreenTitleComponent" insetTop="0">
                 <serializedBean>
-                  <property name="labelFontSizePercent" type="int" value="130"/>
-                  <property name="labelFontStyle" type="enum"
-                            class="com.install4j.runtime.beans.formcomponents.FontStyle" value="BOLD"/>
-                  <property name="labelFontType" type="enum" class="com.install4j.runtime.beans.formcomponents.FontType"
-                            value="DERIVED"/>
+                  <property name="labelFontSizePercent" type="int" value="130" />
+                  <property name="labelFontStyle" type="enum" class="com.install4j.runtime.beans.formcomponents.FontStyle" value="BOLD" />
+                  <property name="labelFontType" type="enum" class="com.install4j.runtime.beans.formcomponents.FontType" value="DERIVED" />
                 </serializedBean>
               </formComponent>
-              <formComponent id="44" beanClass="com.install4j.runtime.beans.formcomponents.SeparatorComponent"/>
-              <formComponent id="45" beanClass="com.install4j.runtime.beans.styles.ContentComponent" insetTop="10"
-                             insetBottom="0"/>
+              <formComponent id="44" beanClass="com.install4j.runtime.beans.formcomponents.SeparatorComponent" />
+              <formComponent id="45" beanClass="com.install4j.runtime.beans.styles.ContentComponent" insetTop="10" insetBottom="0" />
             </beans>
             <externalParametrizationPropertyNames>
               <propertyName>imageAnchor</propertyName>
@@ -1034,14 +928,12 @@
         <beans>
           <style name="Standard header" id="48" beanClass="com.install4j.runtime.beans.styles.FormStyle">
             <serializedBean>
-              <property name="fillVertical" type="boolean" value="false"/>
-              <property name="standalone" type="boolean" value="false"/>
-              <property name="verticalAnchor" type="enum" class="com.install4j.api.beans.Anchor" value="NORTH"/>
+              <property name="fillVertical" type="boolean" value="false" />
+              <property name="standalone" type="boolean" value="false" />
+              <property name="verticalAnchor" type="enum" class="com.install4j.api.beans.Anchor" value="NORTH" />
             </serializedBean>
             <formComponents>
-              <group id="49" beanClass="com.install4j.runtime.beans.groups.VerticalFormComponentGroup"
-                     useExternalParametrization="true" externalParametrizationName="Customize title bar"
-                     externalParametrizationMode="include">
+              <group id="49" beanClass="com.install4j.runtime.beans.groups.VerticalFormComponentGroup" useExternalParametrization="true" externalParametrizationName="Customize title bar" externalParametrizationMode="include">
                 <serializedBean>
                   <property name="backgroundColor">
                     <object class="java.awt.Color">
@@ -1053,11 +945,11 @@
                   </property>
                   <property name="borderSides">
                     <object class="com.install4j.runtime.beans.formcomponents.BorderSides">
-                      <property name="bottom" type="boolean" value="true"/>
+                      <property name="bottom" type="boolean" value="true" />
                     </object>
                   </property>
-                  <property name="imageAnchor" type="enum" class="com.install4j.api.beans.Anchor" value="NORTHEAST"/>
-                  <property name="imageEdgeBorderWidth" type="int" value="2"/>
+                  <property name="imageAnchor" type="enum" class="com.install4j.api.beans.Anchor" value="NORTHEAST" />
+                  <property name="imageEdgeBorderWidth" type="int" value="2" />
                   <property name="imageFile">
                     <object class="com.install4j.api.beans.ExternalFile">
                       <string>icon:${installer:sys.installerApplicationMode}_header.png</string>
@@ -1081,20 +973,15 @@
                   </property>
                 </serializedBean>
                 <beans>
-                  <formComponent name="Title" id="50"
-                                 beanClass="com.install4j.runtime.beans.styles.ScreenTitleComponent">
+                  <formComponent name="Title" id="50" beanClass="com.install4j.runtime.beans.styles.ScreenTitleComponent">
                     <serializedBean>
-                      <property name="labelFontStyle" type="enum"
-                                class="com.install4j.runtime.beans.formcomponents.FontStyle" value="BOLD"/>
-                      <property name="labelFontType" type="enum"
-                                class="com.install4j.runtime.beans.formcomponents.FontType" value="DERIVED"/>
+                      <property name="labelFontStyle" type="enum" class="com.install4j.runtime.beans.formcomponents.FontStyle" value="BOLD" />
+                      <property name="labelFontType" type="enum" class="com.install4j.runtime.beans.formcomponents.FontType" value="DERIVED" />
                     </serializedBean>
                   </formComponent>
-                  <formComponent name="Subtitle" id="51"
-                                 beanClass="com.install4j.runtime.beans.styles.ScreenTitleComponent" insetLeft="8">
+                  <formComponent name="Subtitle" id="51" beanClass="com.install4j.runtime.beans.styles.ScreenTitleComponent" insetLeft="8">
                     <serializedBean>
-                      <property name="titleType" type="enum" class="com.install4j.runtime.beans.styles.TitleType"
-                                value="SUB_TITLE"/>
+                      <property name="titleType" type="enum" class="com.install4j.runtime.beans.styles.TitleType" value="SUB_TITLE" />
                     </serializedBean>
                   </formComponent>
                 </beans>
@@ -1110,14 +997,14 @@
           </style>
           <style name="Standard footer" id="52" beanClass="com.install4j.runtime.beans.styles.FormStyle">
             <serializedBean>
-              <property name="fillVertical" type="boolean" value="false"/>
-              <property name="standalone" type="boolean" value="false"/>
-              <property name="verticalAnchor" type="enum" class="com.install4j.api.beans.Anchor" value="SOUTH"/>
+              <property name="fillVertical" type="boolean" value="false" />
+              <property name="standalone" type="boolean" value="false" />
+              <property name="verticalAnchor" type="enum" class="com.install4j.api.beans.Anchor" value="SOUTH" />
             </serializedBean>
             <formComponents>
               <group id="53" beanClass="com.install4j.runtime.beans.groups.HorizontalFormComponentGroup">
                 <serializedBean>
-                  <property name="alignFirstLabel" type="boolean" value="false"/>
+                  <property name="alignFirstLabel" type="boolean" value="false" />
                   <property name="insets">
                     <object class="java.awt.Insets">
                       <int>3</int>
@@ -1128,30 +1015,23 @@
                   </property>
                 </serializedBean>
                 <beans>
-                  <formComponent id="54" beanClass="com.install4j.runtime.beans.formcomponents.SpringComponent"/>
-                  <formComponent name="Back button" id="55"
-                                 beanClass="com.install4j.runtime.beans.styles.StandardControlButtonComponent">
+                  <formComponent id="54" beanClass="com.install4j.runtime.beans.formcomponents.SpringComponent" />
+                  <formComponent name="Back button" id="55" beanClass="com.install4j.runtime.beans.styles.StandardControlButtonComponent">
                     <serializedBean>
                       <property name="buttonText" type="string">&lt; ${i18n:ButtonBack}</property>
-                      <property name="controlButtonType" type="enum" class="com.install4j.api.context.ControlButtonType"
-                                value="PREVIOUS"/>
+                      <property name="controlButtonType" type="enum" class="com.install4j.api.context.ControlButtonType" value="PREVIOUS" />
                     </serializedBean>
                   </formComponent>
-                  <formComponent name="Next button" id="56"
-                                 beanClass="com.install4j.runtime.beans.styles.StandardControlButtonComponent">
+                  <formComponent name="Next button" id="56" beanClass="com.install4j.runtime.beans.styles.StandardControlButtonComponent">
                     <serializedBean>
                       <property name="buttonText" type="string">${i18n:ButtonNext} &gt;</property>
-                      <property name="controlButtonType" type="enum" class="com.install4j.api.context.ControlButtonType"
-                                value="NEXT"/>
+                      <property name="controlButtonType" type="enum" class="com.install4j.api.context.ControlButtonType" value="NEXT" />
                     </serializedBean>
                   </formComponent>
-                  <formComponent name="Cancel button" id="57"
-                                 beanClass="com.install4j.runtime.beans.styles.StandardControlButtonComponent"
-                                 insetLeft="5">
+                  <formComponent name="Cancel button" id="57" beanClass="com.install4j.runtime.beans.styles.StandardControlButtonComponent" insetLeft="5">
                     <serializedBean>
                       <property name="buttonText" type="string">${i18n:ButtonCancel}</property>
-                      <property name="controlButtonType" type="enum" class="com.install4j.api.context.ControlButtonType"
-                                value="CANCEL"/>
+                      <property name="controlButtonType" type="enum" class="com.install4j.api.context.ControlButtonType" value="CANCEL" />
                     </serializedBean>
                   </formComponent>
                 </beans>
@@ -1163,20 +1043,17 @@
     </styles>
   </installerGui>
   <mediaSets>
-    <windows name="Windows 32" id="63"
-             mediaFileName="${compiler:sys.shortName}_${compiler:sys.platform}_${compiler:sys.version}" jreBitType="32">
+    <windows name="Windows 32" id="63" mediaFileName="${compiler:sys.shortName}_${compiler:sys.platform}_${compiler:sys.version}" jreBitType="32">
       <jreBundle usePack200="false" jreBundleSource="generated">
         <modules>
-          <defaultModules set="all"/>
+          <defaultModules set="all" />
         </modules>
       </jreBundle>
     </windows>
-    <windowsArchive name="Windows Archive" id="65"
-                    mediaFileName="${compiler:sys.shortName}_${compiler:sys.platform}_${compiler:sys.version}"
-                    jreBitType="32">
+    <windowsArchive name="Windows Archive" id="65" mediaFileName="${compiler:sys.shortName}_${compiler:sys.platform}_${compiler:sys.version}" jreBitType="32">
       <jreBundle jdkProviderId="Liberica" jreBundleSource="generated">
         <modules>
-          <defaultModules set="all"/>
+          <defaultModules set="all" />
         </modules>
       </jreBundle>
     </windowsArchive>

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,9 +74,7 @@ jobs:
         - openssl aes-256-cbc -K $encrypted_e4ced02e3beb_key -iv $encrypted_e4ced02e3beb_iv -in scripte/deploy/deploy.key.enc -out scripte/deploy/deploy.key -d
       deploy:
         - provider: script
-          edge: true
           script: scripte/deploy/deploy.sh release linux
-          cleanup: true
           on:
             tags: true
     - stage: Build and Deploy Linux ARM
@@ -86,9 +84,7 @@ jobs:
         - openssl aes-256-cbc -K $encrypted_e4ced02e3beb_key -iv $encrypted_e4ced02e3beb_iv -in scripte/deploy/deploy.key.enc -out scripte/deploy/deploy.key -d
       deploy:
         - provider: script
-          edge: true
           script: scripte/deploy/deploy.sh release linux-armhf
-          cleanup: true
           on:
             tags: true
     - stage: Build and Deploy Windows
@@ -98,9 +94,7 @@ jobs:
         - openssl aes-256-cbc -K $encrypted_e4ced02e3beb_key -iv $encrypted_e4ced02e3beb_iv -in scripte/deploy/deploy.key.enc -out scripte/deploy/deploy.key -d
       deploy:
         - provider: script
-          edge: true
           script: scripte/deploy/deploy.sh release win
-          cleanup: true
           on:
             tags: true
     - stage: Build and Deploy Windows 32bit
@@ -111,6 +105,5 @@ jobs:
       deploy:
         - provider: script
           script: scripte/deploy/deploy.sh release win32
-          cleanup: true
           on:
             tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ stages:
     if: tag IS present
   - name: Build and Deploy Windows
     if: tag IS present
+  - name: Build and Deploy Windows 32bit
+    if: tag IS present
 jobs:
   include:
     - stage: Test

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,12 @@ jobs:
         - echo "Baue AppImage"
         - scripte/appimage.sh
         - scripte/deploy/deploy.sh nightly linux $TRAVIS_COMMIT
-        - ./mvnw clean install -Parm,install4j,!linux
+        - ./mvnw clean install -Parm,!64bit,32bit,install4j,!linux
         - scripte/deploy/deploy.sh nightly linux-armhf $TRAVIS_COMMIT
         - ./mvnw clean install -Pwindows,install4j,!linux
         - scripte/deploy/deploy.sh nightly win $TRAVIS_COMMIT
+        - ./mvnw clean install -Pwindows32,!64bit,32bit,install4j,!linux
+        - scripte/deploy/deploy.sh nightly win32 $TRAVIS_COMMIT
         - ./mvnw clean install -Pmac,!linux
         - scripte/deploy/deploy.sh nightly mac $TRAVIS_COMMIT
       cache:
@@ -77,7 +79,7 @@ jobs:
             tags: true
     - stage: Build and Deploy Linux ARM
       script:
-        - ./mvnw clean install -Parm,install4j,!linux
+        - ./mvnw clean install -Parm,!64bit,32bit,install4j,!linux
       before_deploy:
         - openssl aes-256-cbc -K $encrypted_e4ced02e3beb_key -iv $encrypted_e4ced02e3beb_iv -in scripte/deploy/deploy.key.enc -out scripte/deploy/deploy.key -d
       deploy:
@@ -97,5 +99,16 @@ jobs:
           edge: true
           script: scripte/deploy/deploy.sh release win
           cleanup: true
+          on:
+            tags: true
+    - stage: Build and Deploy Windows 32bit
+      script:
+        - ./mvnw clean install -Pwindows32,!64bit,32bit,!linux,install4j
+      before_deploy:
+        - openssl aes-256-cbc -K $encrypted_e4ced02e3beb_key -iv $encrypted_e4ced02e3beb_iv -in scripte/deploy/deploy.key.enc -out scripte/deploy/deploy.key -d
+      deploy:
+        - provider: script
+          script: scripte/deploy/deploy.sh release win32
+          skip_cleanup: true
           on:
             tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,6 +111,6 @@ jobs:
       deploy:
         - provider: script
           script: scripte/deploy/deploy.sh release win32
-          skip_cleanup: true
+          cleanup: true
           on:
             tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ jobs:
           - .autoconf
           - $HOME/.m2
     - stage: Build and Deploy Snapshots
-      cleanup: true
       script:
         - openssl aes-256-cbc -K $encrypted_e4ced02e3beb_key -iv $encrypted_e4ced02e3beb_iv -in scripte/deploy/deploy.key.enc -out scripte/deploy/deploy.key -d
         - ./mvnw clean install -Plinux,install4j

--- a/pom.xml
+++ b/pom.xml
@@ -483,6 +483,7 @@
 				<version>3.8.1</version>
 				<configuration>
 					<release>${jdk.language.version}</release>
+					<forceJavacCompilerUse>true</forceJavacCompilerUse>
 					<compilerArgs>--enable-preview</compilerArgs>
 					<annotationProcessorPaths>
 						<path>
@@ -586,7 +587,9 @@
 		<profile>
 			<id>64bit</id>
 			<activation>
-				<activeByDefault>true</activeByDefault>
+				<os>
+					<arch>amd64</arch>
+				</os>
 			</activation>
 			<dependencies>
 				<!-- JavaFX -->

--- a/pom.xml
+++ b/pom.xml
@@ -731,9 +731,6 @@
 										</transformer>
 										<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
 									</transformers>
-									<excludes>
-										<exclude>res/*</exclude>
-									</excludes>
 								</configuration>
 							</execution>
 						</executions>
@@ -779,9 +776,6 @@
 										<transformer
 												implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
 									</transformers>
-									<excludes>
-										<exclude>res/*</exclude>
-									</excludes>
 								</configuration>
 							</execution>
 						</executions>
@@ -827,9 +821,6 @@
 											<mainClass>${mainclass}</mainClass>
 										</transformer>
 									</transformers>
-									<excludes>
-										<exclude>res/*</exclude>
-									</excludes>
 								</configuration>
 							</execution>
 						</executions>
@@ -870,9 +861,6 @@
 											<mainClass>${mainclass}</mainClass>
 										</transformer>
 									</transformers>
-									<excludes>
-										<exclude>res/*</exclude>
-									</excludes>
 								</configuration>
 							</execution>
 						</executions>
@@ -917,9 +905,6 @@
 											<mainClass>${mainclass}</mainClass>
 										</transformer>
 									</transformers>
-									<excludes>
-										<exclude>res/*</exclude>
-									</excludes>
 								</configuration>
 							</execution>
 						</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -584,16 +584,10 @@
 
 	<profiles>
 		<profile>
-			<id>windows</id>
+			<id>64bit</id>
 			<activation>
-				<os>
-					<family>windows</family>
-				</os>
+				<activeByDefault>true</activeByDefault>
 			</activation>
-			<properties>
-				<javafx.platform>win</javafx.platform>
-				<install4j.platform>windows</install4j.platform>
-			</properties>
 			<dependencies>
 				<!-- JavaFX -->
 				<dependency>
@@ -639,6 +633,73 @@
 					<classifier>${javafx.platform}</classifier>
 				</dependency>
 			</dependencies>
+		</profile>
+		<profile>
+			<id>32bit</id>
+			<dependencies>
+				<!-- JavaFX -->
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-base</artifactId>
+					<version>${javafx.version}</version>
+					<classifier>${javafx.platform}</classifier>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-controls</artifactId>
+					<version>${javafx.version}</version>
+					<classifier>${javafx.platform}</classifier>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-media</artifactId>
+					<version>${javafx.version}</version>
+					<classifier>${javafx.platform}</classifier>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-swing</artifactId>
+					<version>${javafx.version}</version>
+					<classifier>${javafx.platform}</classifier>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-web</artifactId>
+					<version>${javafx.version}</version>
+					<classifier>${javafx.platform}</classifier>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-fxml</artifactId>
+					<version>${javafx.version}</version>
+					<classifier>${javafx.platform}</classifier>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-graphics</artifactId>
+					<version>${javafx.version}</version>
+					<classifier>${javafx.platform}</classifier>
+					<scope>provided</scope>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>windows</id>
+			<activation>
+				<os>
+					<family>windows</family>
+				</os>
+			</activation>
+			<properties>
+				<javafx.platform>win</javafx.platform>
+				<install4j.platform>windows</install4j.platform>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>
@@ -681,6 +742,54 @@
 			</build>
 		</profile>
 		<profile>
+			<id>windows32</id>
+			<properties>
+				<javafx.platform>win</javafx.platform>
+				<install4j.platform>windows32</install4j.platform>
+			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-shade-plugin</artifactId>
+						<version>3.2.0</version>
+						<executions>
+							<execution>
+								<phase>package</phase>
+								<goals>
+									<goal>shade</goal>
+								</goals>
+								<configuration>
+									<artifactSet>
+										<excludes>
+											<exclude>res/*</exclude>
+											<exclude>*:*:*:linux</exclude>
+											<exclude>*:*:*:mac</exclude>
+										</excludes>
+									</artifactSet>
+									<shadedArtifactAttached>false</shadedArtifactAttached>
+									<transformers>
+										<transformer
+												implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+											<mainClass>${mainclass}</mainClass>
+											<manifestEntries>
+												<Multi-Release>true</Multi-Release>
+											</manifestEntries>
+										</transformer>
+										<transformer
+												implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+									</transformers>
+									<excludes>
+										<exclude>res/*</exclude>
+									</excludes>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
 			<id>linux</id>
 			<activation>
 				<os>
@@ -691,51 +800,6 @@
 				<javafx.platform>linux</javafx.platform>
 				<install4j.platform>linux</install4j.platform>
 			</properties>
-			<dependencies>
-				<!-- JavaFX -->
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-base</artifactId>
-					<version>${javafx.version}</version>
-					<classifier>${javafx.platform}</classifier>
-				</dependency>
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-controls</artifactId>
-					<version>${javafx.version}</version>
-					<classifier>${javafx.platform}</classifier>
-				</dependency>
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-media</artifactId>
-					<version>${javafx.version}</version>
-					<classifier>${javafx.platform}</classifier>
-				</dependency>
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-swing</artifactId>
-					<version>${javafx.version}</version>
-					<classifier>${javafx.platform}</classifier>
-				</dependency>
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-web</artifactId>
-					<version>${javafx.version}</version>
-					<classifier>${javafx.platform}</classifier>
-				</dependency>
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-fxml</artifactId>
-					<version>${javafx.version}</version>
-					<classifier>${javafx.platform}</classifier>
-				</dependency>
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-graphics</artifactId>
-					<version>${javafx.version}</version>
-					<classifier>${javafx.platform}</classifier>
-				</dependency>
-			</dependencies>
 			<build>
 				<plugins>
 					<plugin>
@@ -779,58 +843,6 @@
 				<javafx.platform>linux</javafx.platform>
 				<install4j.platform>arm</install4j.platform>
 			</properties>
-			<dependencies>
-				<!-- JavaFX -->
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-base</artifactId>
-					<version>${javafx.version}</version>
-					<classifier>${javafx.platform}</classifier>
-					<scope>provided</scope>
-				</dependency>
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-controls</artifactId>
-					<version>${javafx.version}</version>
-					<classifier>${javafx.platform}</classifier>
-					<scope>provided</scope>
-				</dependency>
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-media</artifactId>
-					<version>${javafx.version}</version>
-					<classifier>${javafx.platform}</classifier>
-					<scope>provided</scope>
-				</dependency>
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-swing</artifactId>
-					<version>${javafx.version}</version>
-					<classifier>${javafx.platform}</classifier>
-					<scope>provided</scope>
-				</dependency>
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-web</artifactId>
-					<version>${javafx.version}</version>
-					<classifier>${javafx.platform}</classifier>
-					<scope>provided</scope>
-				</dependency>
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-fxml</artifactId>
-					<version>${javafx.version}</version>
-					<classifier>${javafx.platform}</classifier>
-					<scope>provided</scope>
-				</dependency>
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-graphics</artifactId>
-					<version>${javafx.version}</version>
-					<classifier>${javafx.platform}</classifier>
-					<scope>provided</scope>
-				</dependency>
-			</dependencies>
 			<build>
 				<plugins>
 					<plugin>
@@ -878,51 +890,6 @@
 			<properties>
 				<javafx.platform>mac</javafx.platform>
 			</properties>
-			<dependencies>
-				<!-- JavaFX -->
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-base</artifactId>
-					<version>${javafx.version}</version>
-					<classifier>${javafx.platform}</classifier>
-				</dependency>
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-controls</artifactId>
-					<version>${javafx.version}</version>
-					<classifier>${javafx.platform}</classifier>
-				</dependency>
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-media</artifactId>
-					<version>${javafx.version}</version>
-					<classifier>${javafx.platform}</classifier>
-				</dependency>
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-swing</artifactId>
-					<version>${javafx.version}</version>
-					<classifier>${javafx.platform}</classifier>
-				</dependency>
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-web</artifactId>
-					<version>${javafx.version}</version>
-					<classifier>${javafx.platform}</classifier>
-				</dependency>
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-fxml</artifactId>
-					<version>${javafx.version}</version>
-					<classifier>${javafx.platform}</classifier>
-				</dependency>
-				<dependency>
-					<groupId>org.openjfx</groupId>
-					<artifactId>javafx-graphics</artifactId>
-					<version>${javafx.version}</version>
-					<classifier>${javafx.platform}</classifier>
-				</dependency>
-			</dependencies>
 			<build>
 				<plugins>
 					<plugin>

--- a/res/bin/ffmpeg.exe
+++ b/res/bin/ffmpeg.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ac89ee34933a72205de6e6ec6f3bbc65558d51fb6d64a5768f9138e3e1a1811
-size 67081216
+oid sha256:de0e96a1497b9e06598bedbd77e29bee5dc4f8ec9eecaacf66cb18e011fb19e3
+size 68655104

--- a/res/bin/ffmpeg.txt
+++ b/res/bin/ffmpeg.txt
@@ -1,6 +1,6 @@
 Zeranoe FFmpeg Builds <http://ffmpeg.zeranoe.com/builds/>
 
-Build: ffmpeg-4.2.1-win64-static
+Build: ffmpeg-4.3-win64-static
 
 Configuration:
   --enable-gpl
@@ -15,12 +15,13 @@ Configuration:
   --enable-libfreetype
   --enable-libmp3lame
   --enable-libopencore-amrnb
-  --enable-libopencore-amrwb
+  --enable-libopencore-amrwb    
   --enable-libopenjpeg
   --enable-libopus
   --enable-libshine
   --enable-libsnappy
   --enable-libsoxr
+  --enable-libsrt
   --enable-libtheora
   --enable-libtwolame
   --enable-libvpx
@@ -34,15 +35,18 @@ Configuration:
   --enable-zlib
   --enable-gmp
   --enable-libvidstab
+  --enable-libvmaf
   --enable-libvorbis
   --enable-libvo-amrwbenc
   --enable-libmysofa
   --enable-libspeex
   --enable-libxvid
   --enable-libaom
+  --enable-libgsm
+  --disable-w32threads
   --enable-libmfx
-  --enable-amf
   --enable-ffnvcodec
+  --enable-cuda-llvm
   --enable-cuvid
   --enable-d3d11va
   --enable-nvenc
@@ -50,48 +54,51 @@ Configuration:
   --enable-dxva2
   --enable-avisynth
   --enable-libopenmpt
+  --enable-amf
 
 Libraries:
-  SDL               20190910-0c66be7  <https://libsdl.org>
-  Fontconfig        2.13.0            <http://freedesktop.org/wiki/Software/fontconfig>
-  GnuTLS            3.6.9             <https://gnutls.org/>
-  libiconv          1.15              <http://gnu.org/software/libiconv>
-  libass            0.14.0            <https://github.com/libass/libass>
-  dav1d             20190910-556890b  <https://code.videolan.org/videolan/dav1d>
-  libbluray         20180913-2d18c70  <https://www.videolan.org/developers/libbluray.html>
-  FreeType          2.10.1            <http://freetype.sourceforge.net>
+  SDL               20200619-fb6395c  <https://libsdl.org>
+  Fontconfig        2.13.92           <http://freedesktop.org/wiki/Software/fontconfig>
+  GnuTLS            3.6.14            <https://gnutls.org/>
+  libiconv          1.16              <http://gnu.org/software/libiconv>
+  libass            20200615-7959e61  <https://github.com/libass/libass>
+  dav1d             20200621-54f9206  <https://code.videolan.org/videolan/dav1d>
+  libbluray         20200517-245baa7  <https://www.videolan.org/developers/libbluray.html>
+  FreeType          2.10.2            <http://freetype.sourceforge.net>
   LAME              3.100             <http://lame.sourceforge.net>
   OpenCORE AMR      20170731-07a5be4  <https://sourceforge.net/projects/opencore-amr>
-  OpenJPEG          20190903-e66125f  <https://github.com/uclouvain/openjpeg>
-  Opus              20190903-cd529ed  <https://opus-codec.org>
+  OpenJPEG          20200610-25fb144  <https://github.com/uclouvain/openjpeg>
+  Opus              20200618-f8ed894  <https://opus-codec.org>
   shine             20190420-76ea4f0  <https://github.com/savonet/shine>
-  Snappy            1.1.7             <https://github.com/google/snappy>
+  Snappy            1.1.8             <https://github.com/google/snappy>
   libsoxr           20180224-945b592  <http://sourceforge.net/projects/soxr>
-  Theora            20171023-e5d205b  <http://theora.org>
-  TwoLAME           0.3.13            <http://twolame.org>
-  vpx               20190911-8025696  <http://webmproject.org>
-  WavPack           5.1.0             <http://wavpack.com>
-  WebP              20190904-af650c0  <https://developers.google.com/speed/webp>
-  x264              20190717-3759fcb  <https://www.videolan.org/developers/x264.html>
-  x265              20190813-c4b098f  <https://bitbucket.org/multicoreware/x265/wiki/Home>
-  libxml2           2.9.9             <http://xmlsoft.org>
-  z.lib             20190914-72b6bec  <https://github.com/sekrit-twc/zimg>
-  XZ Utils          5.2.4             <http://tukaani.org/xz>
+  SRT               20200520-9f7068d  <https://www.srtalliance.org>
+  Theora            20200618-f98989a  <http://theora.org>
+  TwoLAME           0.4.0             <http://twolame.org>
+  vpx               20200619-d9a69a1  <http://webmproject.org>
+  WavPack           5.3.0             <http://wavpack.com>
+  WebP              20200505-e3c259a  <https://developers.google.com/speed/webp>
+  x264              20200615-4c9b076  <https://www.videolan.org/developers/x264.html>
+  x265              20200529-73ca1d7  <https://bitbucket.org/multicoreware/x265/wiki/Home>
+  libxml2           2.9.10            <http://xmlsoft.org>
+  z.lib             20200604-6dec143  <https://github.com/sekrit-twc/zimg>
+  XZ Utils          5.2.5             <http://tukaani.org/xz>
   zlib              1.2.11            <http://zlib.net>
-  GMP               6.1.2             <https://gmplib.org>
+  GMP               6.2.0             <https://gmplib.org>
   vid.stab          20190213-aeabc8d  <http://public.hronopik.de/vid.stab>
-  Vorbis            20190128-9eadecc  <http://vorbis.com>
+  VMAF              20200617-3ff32b8  <https://github.com/Netflix/vmaf>
+  Vorbis            20200616-5fd186e  <http://vorbis.com>
   VisualOn AMR-WB   20141107-3b3fcd0  <https://sourceforge.net/projects/opencore-amr>
-  libmysofa         20190516-3dba53f  <https://github.com/hoene/libmysofa>
-  Speex             20190808-58ac1d4  <http://speex.org>
+  libmysofa         20200614-90f0089  <https://github.com/hoene/libmysofa>
+  Speex             20191110-7db954e  <http://speex.org>
   Xvid              1.3.5             <https://labs.xvid.com>
-  aom               20190913-861fd02  <https://aomedia.googlesource.com/aom>
-  libmfx            1.27              <https://software.intel.com/en-us/media-sdk>
-  AMF               20190828-95220c0  <https://gpuopen.com/gaming-product/advanced-media-framework>
-  nv-codec-headers  20190913-4094cc6  <https://git.videolan.org/?p=ffmpeg/nv-codec-headers.git>
-  OpenMPT           20190806-2426ee5  <https://openmpt.org>
-
-Copyright (C) 2019 Kyle Schwarz
+  aom               20200620-8c113ea  <https://aomedia.googlesource.com/aom>
+  GSM               1.0.19            <http://quut.com/gsm/>
+  libmfx            1.28              <https://software.intel.com/en-us/media-sdk>
+  nv-codec-headers  20191126-250292d  <https://git.videolan.org/?p=ffmpeg/nv-codec-headers.git>
+  AviSynth+         20200619-1eb7ce6  <https://github.com/AviSynth/AviSynthPlus>
+  OpenMPT           20200621-9082512  <https://openmpt.org>
+  AMF               20200515-802f92e  <https://gpuopen.com/gaming-product/advanced-media-framework>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/res/bin/ffmpeg32.exe
+++ b/res/bin/ffmpeg32.exe
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c9d51e085f9c2921616a040554cd3e621c265f01aa2d13fac918dcdc6e9ae3a
+size 53479424

--- a/res/bin/ffmpeg32.txt
+++ b/res/bin/ffmpeg32.txt
@@ -1,0 +1,114 @@
+Zeranoe FFmpeg Builds <http://ffmpeg.zeranoe.com/builds/>
+
+Build: ffmpeg-4.3-win32-static
+
+Configuration:
+  --enable-gpl
+  --enable-version3
+  --enable-sdl2
+  --enable-fontconfig
+  --enable-gnutls
+  --enable-iconv
+  --enable-libass
+  --enable-libdav1d
+  --enable-libbluray
+  --enable-libfreetype
+  --enable-libmp3lame
+  --enable-libopencore-amrnb
+  --enable-libopencore-amrwb
+  --enable-libopenjpeg
+  --enable-libopus
+  --enable-libshine
+  --enable-libsnappy
+  --enable-libsoxr
+  --enable-libsrt
+  --enable-libtheora
+  --enable-libtwolame
+  --enable-libvpx
+  --enable-libwavpack
+  --enable-libwebp
+  --enable-libx264
+  --enable-libx265
+  --enable-libxml2
+  --enable-libzimg
+  --enable-lzma
+  --enable-zlib
+  --enable-gmp
+  --enable-libvidstab
+  --enable-libvmaf
+  --enable-libvorbis
+  --enable-libvo-amrwbenc
+  --enable-libmysofa
+  --enable-libspeex
+  --enable-libxvid
+  --enable-libaom
+  --enable-libgsm
+  --disable-w32threads
+  --enable-libmfx
+  --enable-ffnvcodec
+  --enable-cuda-llvm
+  --enable-cuvid
+  --enable-d3d11va
+  --enable-nvenc
+  --enable-nvdec
+  --enable-dxva2
+  --enable-avisynth
+  --enable-libopenmpt
+  --enable-amf
+
+Libraries:
+  SDL               20200619-fb6395c  <https://libsdl.org>
+  Fontconfig        2.13.92           <http://freedesktop.org/wiki/Software/fontconfig>
+  GnuTLS            3.6.14            <https://gnutls.org/>
+  libiconv          1.16              <http://gnu.org/software/libiconv>
+  libass            20200615-7959e61  <https://github.com/libass/libass>
+  dav1d             20200621-54f9206  <https://code.videolan.org/videolan/dav1d>
+  libbluray         20200517-245baa7  <https://www.videolan.org/developers/libbluray.html>
+  FreeType          2.10.2            <http://freetype.sourceforge.net>
+  LAME              3.100             <http://lame.sourceforge.net>
+  OpenCORE AMR      20170731-07a5be4  <https://sourceforge.net/projects/opencore-amr>
+  OpenJPEG          20200610-25fb144  <https://github.com/uclouvain/openjpeg>
+  Opus              20200618-f8ed894  <https://opus-codec.org>
+  shine             20190420-76ea4f0  <https://github.com/savonet/shine>
+  Snappy            1.1.8             <https://github.com/google/snappy>
+  libsoxr           20180224-945b592  <http://sourceforge.net/projects/soxr>
+  SRT               20200520-9f7068d  <https://www.srtalliance.org>
+  Theora            20200618-f98989a  <http://theora.org>
+  TwoLAME           0.4.0             <http://twolame.org>
+  vpx               20200619-d9a69a1  <http://webmproject.org>
+  WavPack           5.3.0             <http://wavpack.com>
+  WebP              20200505-e3c259a  <https://developers.google.com/speed/webp>
+  x264              20200615-4c9b076  <https://www.videolan.org/developers/x264.html>
+  x265              20200529-73ca1d7  <https://bitbucket.org/multicoreware/x265/wiki/Home>
+  libxml2           2.9.10            <http://xmlsoft.org>
+  z.lib             20200604-6dec143  <https://github.com/sekrit-twc/zimg>
+  XZ Utils          5.2.5             <http://tukaani.org/xz>
+  zlib              1.2.11            <http://zlib.net>
+  GMP               6.2.0             <https://gmplib.org>
+  vid.stab          20190213-aeabc8d  <http://public.hronopik.de/vid.stab>
+  VMAF              20200617-3ff32b8  <https://github.com/Netflix/vmaf>
+  Vorbis            20200616-5fd186e  <http://vorbis.com>
+  VisualOn AMR-WB   20141107-3b3fcd0  <https://sourceforge.net/projects/opencore-amr>
+  libmysofa         20200614-90f0089  <https://github.com/hoene/libmysofa>
+  Speex             20191110-7db954e  <http://speex.org>
+  Xvid              1.3.5             <https://labs.xvid.com>
+  aom               20200620-8c113ea  <https://aomedia.googlesource.com/aom>
+  GSM               1.0.19            <http://quut.com/gsm/>
+  libmfx            1.28              <https://software.intel.com/en-us/media-sdk>
+  nv-codec-headers  20191126-250292d  <https://git.videolan.org/?p=ffmpeg/nv-codec-headers.git>
+  AviSynth+         20200619-1eb7ce6  <https://github.com/AviSynth/AviSynthPlus>
+  OpenMPT           20200621-9082512  <https://openmpt.org>
+  AMF               20200515-802f92e  <https://gpuopen.com/gaming-product/advanced-media-framework>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.


### PR DESCRIPTION
Added Windows 32bit support by creating a install4j file which creates a Zip and a installer Exe for Windows 32bit by using Liberica JDK like for the ARM one.
Liberica includes JavaFX aldready so for Win32 and ARM the JavaFX dependencies are only provided. 
To get the pom a little bit smaller I created two new profiles one 64bit with the JavaFX dependencies with default scope and one for 32bit with scope provided. The 64bit one is default.

I tested the resulting Win32 installer with a Win 7 32bit VM. @me-like-cookies also tested it. See #520
