### PR TITLE
Sicherstellen dass mit JDK 14 gebaut wird

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -417,6 +417,26 @@
         <finalName>MediathekView</finalName>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>${java.version}</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
                 <version>3.1.0</version>
             </plugin>


### PR DESCRIPTION
maven-enforcer plugin stellt sicher dass mit JDK 14 gebaut wird