### PR TITLE
Switch from AdoptOpenJDK to Adoptium (Eclipse Temurin runtime)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,9 +75,10 @@ jobs:
         with:
           ref: develop
       - name: Set up JDK 16
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 16
+          distribution: 'temurin'
+          java-version: '16'
       - uses: AdoptOpenJDK/install-jdk@v1
         with:
           version: '8'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ variables:
   MAVEN_OPTS: "-Djava.awt.headless=true -Dmaven.repo.local=./.m2/repository"
   MAVEN_CLI_OPTS: "-B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 
-image: maven:3.8-adoptopenjdk-16
+image: maven:3.8-eclipse-temurin-16
 
 
 cache:

--- a/.install4j/mediathekview_arm.install4j
+++ b/.install4j/mediathekview_arm.install4j
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<install4j version="9.0.4" transformSequenceNumber="9">
+<install4j version="9.0.5" transformSequenceNumber="9">
   <directoryPresets config="${project.basedir}/.install4j" />
   <application name="MediathekView" applicationId="1927-5045-2127-3394" mediaDir="target" mediaFilePattern="${compiler:sys.shortName}-${compiler:sys.version}-linux-armhf" shortName="MediathekView" publisher="MediathekView Team" publisherWeb="https://mediathekview.de" version="${project.version}" convertDotsToUnderscores="false" macVolumeId="d594baf3c2b3424d" javaMinVersion="${install4j.jdk.min-version}">
     <languages>

--- a/.install4j/mediathekview_linux.install4j
+++ b/.install4j/mediathekview_linux.install4j
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<install4j version="9.0.4" transformSequenceNumber="9">
+<install4j version="9.0.5" transformSequenceNumber="9">
   <directoryPresets config="${project.basedir}/.install4j" />
   <application name="MediathekView" applicationId="1927-5045-2127-3394" mediaDir="target" mediaFilePattern="${compiler:sys.shortName}-${compiler:sys.version}-linux" shortName="MediathekView" publisher="MediathekView Team" publisherWeb="https://mediathekview.de" version="${project.version}" convertDotsToUnderscores="false" macVolumeId="d594baf3c2b3424d" javaMinVersion="${install4j.jdk.min-version}">
     <languages>
       <principalLanguage id="de" />
     </languages>
-    <jreBundles jdkProviderId="AdoptOpenJDK" release="${install4j.adoptopenjdk.jdk.version}" />
+    <jreBundles jdkProviderId="Adoptium" release="${install4j.adoptium.jdk.version}" />
   </application>
   <files preserveSymlinks="false">
     <mountPoints>

--- a/.install4j/mediathekview_windows.install4j
+++ b/.install4j/mediathekview_windows.install4j
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<install4j version="9.0.4" transformSequenceNumber="9">
+<install4j version="9.0.5" transformSequenceNumber="9">
   <directoryPresets config="${project.build.directory}/res" />
   <application name="MediathekView" applicationId="1927-5045-2127-3394" mediaDir="target" mediaFilePattern="${compiler:sys.shortName}-${compiler:sys.version}-win" shortName="MediathekView" publisher="MediathekView Team" publisherWeb="https://mediathekview.de" version="${project.version}" convertDotsToUnderscores="false" macVolumeId="d594baf3c2b3424d" javaMinVersion="${install4j.jdk.min-version}">
     <languages>
       <principalLanguage id="de" />
     </languages>
-    <jreBundles jdkProviderId="AdoptOpenJDK" release="${install4j.adoptopenjdk.jdk.version}" />
+    <jreBundles jdkProviderId="Adoptium" release="${install4j.adoptium.jdk.version}" />
   </application>
   <files preserveSymlinks="false">
     <mountPoints>

--- a/.install4j/mediathekview_windows32.install4j
+++ b/.install4j/mediathekview_windows32.install4j
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<install4j version="9.0.4" transformSequenceNumber="9">
+<install4j version="9.0.5" transformSequenceNumber="9">
   <directoryPresets config="/home/nicklas/git/MediathekView" />
   <application name="MediathekView" applicationId="1927-5045-2127-3394" mediaDir="target" mediaFilePattern="${compiler:sys.shortName}-${compiler:sys.version}-win32" shortName="MediathekView" publisher="MediathekView Team" publisherWeb="https://mediathekview.de" version="${project.version}" convertDotsToUnderscores="false" macVolumeId="d594baf3c2b3424d" javaMinVersion="${install4j.jdk.min-version}">
     <languages>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/mediat
 
 As MediathekView is written in java you need to have a JDK installed for the correct java version. You can find the currently used java version in the [pom.xml](https://github.com/mediathekview/MediathekView/blob/master/pom.xml) tag `jdk.language.version`.
 
-> We can recommend to use [SDKMan](https://sdkman.io/) to install the right [AdoptOpenJDK](https://adoptopenjdk.net/) version.
+> We recommend using [SDKMan](https://sdkman.io/) to install the right Eclipse [Temurin](https://adoptium.net/) version from Adoptium (formerly AdoptOpenJDK).
 
 **Building:**
 

--- a/pom.xml
+++ b/pom.xml
@@ -95,11 +95,11 @@
         <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
         <guava.version>30.1.1-jre</guava.version>
         <install4j-maven-plugin.version>1.1.2</install4j-maven-plugin.version>
-        <jackson.version>2.12.4</jackson.version>
+        <jackson.version>2.12.5</jackson.version>
         <javafx.version>16</javafx.version>
         <javax.transaction-api.version>1.3</javax.transaction-api.version>
-        <jna.version>5.8.0</jna.version>
-        <junit.jupiter.version>5.7.2</junit.jupiter.version>
+        <jna.version>5.9.0</jna.version>
+        <junit.jupiter.version>5.8.0</junit.jupiter.version>
         <log4j2.version>2.14.1</log4j2.version>
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
@@ -113,19 +113,19 @@
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <miglayout.version>11.0</miglayout.version>
-        <mockito.version>3.11.2</mockito.version>
+        <mockito.version>3.12.4</mockito.version>
         <okhttp.version>4.9.1</okhttp.version>
         <picocli.version>4.6.1</picocli.version>
-        <sqlite-jdbc.version>3.36.0.1</sqlite-jdbc.version>
+        <sqlite-jdbc.version>3.36.0.3</sqlite-jdbc.version>
         <tilesfx.version>16.0.3</tilesfx.version>
         <xz.version>1.9</xz.version>
 
         <mainclass>mediathek.Main</mainclass>
 
-        <!-- AdopOpenJDK is used for Windows and Linux 64bit -->
-        <install4j.adoptopenjdk.jdk.version>16/jdk-16.0.1+9</install4j.adoptopenjdk.jdk.version>
+        <!-- Adoptium (Eclipse Temurin runtime, formerly AdoptOpenJDK) is used for Windows and Linux 64bit -->
+        <install4j.adoptium.jdk.version>16/jdk-16.0.2+7</install4j.adoptium.jdk.version>
         <!-- Liberica includes JavaFX and is used for Arm and 32bit -->
-        <install4j.liberica.jdk.version>16/16.0.1+9</install4j.liberica.jdk.version>
+        <install4j.liberica.jdk.version>16/16.0.2+7</install4j.liberica.jdk.version>
         <install4j.jdk.min-version>16</install4j.jdk.min-version>
 
         <!-- VM Parameters Windows x64 -->
@@ -137,7 +137,7 @@
         <!-- VM Parameters Linux x32 -->
         <install4j.vmparameters.linux.32>-Xmx1280M -XX:+UseG1GC -XX:+UseStringDeduplication -Dfile.encoding=UTF-8 -DexternalUpdateCheck --add-exports javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED --add-exports javafx.base/com.sun.javafx.event=ALL-UNNAMED --add-exports javafx.controls/com.sun.javafx.scene.control.behavior=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.scene.traversal=ALL-UNNAMED</install4j.vmparameters.linux.32>
 
-        <install4j.home>./install4j9.0.4</install4j.home>
+        <install4j.home>./install4j9.0.5</install4j.home>
         <!--suppress UnresolvedMavenProperty -->
         <install4j.licenseKey>${env.LICENSE_KEY_9}</install4j.licenseKey>
         <kotlin.version>1.5.30</kotlin.version>


### PR DESCRIPTION
[install4j 9.0.5](https://www.ej-technologies.com/download/install4j/changelog.html) introduced support for Adoptium (Eclipse Temurin runtime) and defaults to it.

Dependencies and relevant pipelines upgraded.