### PR TITLE
update log4j to 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <javax.transaction-api.version>1.3</javax.transaction-api.version>
         <jna.version>5.10.0</jna.version>
         <junit.jupiter.version>5.8.0</junit.jupiter.version>
-        <log4j2.version>2.15.0</log4j2.version>
+        <log4j2.version>2.17.0</log4j2.version>
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>


### PR DESCRIPTION
following apache log4j team security recommendations
https://logging.apache.org/log4j/2.x/security.html#CVE-2021-45105