### PR TITLE
Use standard download directory on Linux desktop

### DIFF
--- a/src/test/kotlin/mediathek/config/StandardLocationsTest.kt
+++ b/src/test/kotlin/mediathek/config/StandardLocationsTest.kt
@@ -1,9 +1,12 @@
 package mediathek.config
 
 import org.apache.commons.lang3.SystemUtils
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.nio.file.Paths
+import kotlin.io.path.isDirectory
+import kotlin.io.path.relativeToOrNull
 
 internal class StandardLocationsTest {
 
@@ -23,13 +26,26 @@ internal class StandardLocationsTest {
     }
 
     @Test
+    fun getXDGDownloadDirectory() {
+        if (SystemUtils.IS_OS_LINUX) {
+            assertTrue { StandardLocations.getXDGDownloadDirectory().isPresent }
+            assertTrue { StandardLocations.getXDGDownloadDirectory().get().isDirectory() }
+            assertTrue { StandardLocations.getXDGDownloadDirectory().get().relativeToOrNull(Paths.get(SystemUtils.USER_HOME)) != null }
+        } else {
+            assertTrue { StandardLocations.getXDGDownloadDirectory().isEmpty }
+        }
+    }
+
+    @Test
     fun getStandardDownloadPath() {
         val path = if (SystemUtils.IS_OS_MAC_OSX) {
             Paths.get(SystemUtils.USER_HOME, "Downloads")
+        } else if (SystemUtils.IS_OS_LINUX) {
+            StandardLocations.getXDGDownloadDirectory().orElse(Paths.get(SystemUtils.USER_HOME, Konstanten.VERZEICHNIS_DOWNLOADS))
         } else {
             Paths.get(SystemUtils.USER_HOME, Konstanten.VERZEICHNIS_DOWNLOADS)
         }
         val loc2 = path.toAbsolutePath().toString()
-        assertTrue { StandardLocations.getStandardDownloadPath() == loc2 }
+        assertEquals(StandardLocations.getStandardDownloadPath(), loc2)
     }
 }


### PR DESCRIPTION
Use xdg-user-dir to find the standard download directory on Unix desktops, see <https://www.freedesktop.org/wiki/Software/xdg-user-dirs/>.

If xdg-user-dir doesn't exist or doesn't return anything, fall back to `~/MediathekView` as before.
