### PR TITLE
On Linux, detect Dark Mode of Gnome

### DIFF
--- a/src/main/java/mediathek/tool/DarkModeDetector.java
+++ b/src/main/java/mediathek/tool/DarkModeDetector.java
@@ -55,7 +55,7 @@ public class DarkModeDetector {
 
         try {
             boolean           isDarkMode = false;
-            var process    = Runtime.getRuntime().exec("defaults read -g AppleInterfaceStyle");
+            var process    = Runtime.getRuntime().exec(new String[]{"defaults", "read", "-g", "AppleInterfaceStyle"});
             isr        = new InputStreamReader(process.getInputStream());
             rdr        = new BufferedReader(isr);
             String            line;
@@ -110,7 +110,7 @@ public class DarkModeDetector {
         try {
             Integer           colorKey    = null;
             Runtime           runtime    = Runtime.getRuntime();
-            Process           process    = runtime.exec("defaults read -g AppleAccentColor");
+            Process           process    = runtime.exec(new String[]{"defaults", "read", "-g", "AppleAccentColor"});
             InputStreamReader isr        = new InputStreamReader(process.getInputStream());
             BufferedReader    rdr        = new BufferedReader(isr);
             String            line;


### PR DESCRIPTION
Detects Gnome Dark mode by reading the corresponding interface setting from Gnome.

## Notes

I also drive-by-fixed a use of a deprecated overload of Runtime.exec in the mac OS implementation. I hope that's fine, but if you like I can also remove that commit again.

The subprocess stuff in isMacOsDarkMode felt overly complicated to me, so I used a shorter and simpler approach in the Gnome implementation, but I'm only superficially familiar with Java so I may have overlooked potential issues in my approach.  If you like I can also change the code to look like the macOS stuff.

When testing I noticed that the method is called, and the result is printed on stdout, but the interface stays light regardless of whether dark mode is enabled or not… which I found a bit disappointing; I had hoped mediathekview would follow dark mode automatically.  What's the reason for detecting dark mode but then not following it?  Just not implemented so far?  If so, is it planned?