### PR TITLE
Fix class path for dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -618,6 +618,7 @@
                         <manifest>
                             <addClasspath>true</addClasspath>
                             <mainClass><![CDATA[${mainclass}]]></mainClass>
+                            <classpathPrefix>dependency/</classpathPrefix>
                         </manifest>
                     </archive>
                 </configuration>


### PR DESCRIPTION
Since 25934bc dependencies are not bundled in the jar anymore but have their own respectve jar file in the build output directory under `dependency`. This change adds that directory to the class path in the manifest.

Fixes #795