### PR TITLE
Add host header to JDownloader HTTP requests

### DIFF
--- a/src/main/java/mediathek/gui/tabs/tab_film/JDownloadHelper.kt
+++ b/src/main/java/mediathek/gui/tabs/tab_film/JDownloadHelper.kt
@@ -30,6 +30,7 @@ class JDownloadHelper {
             .build()
         val request = Request.Builder()
             .url("http://127.0.0.1:9666/flash/add")
+            .header("Host", "mediathekview.de")
             .post(formBody)
             .build()
         try {


### PR DESCRIPTION
Sending to the JDownloader api will present a popup in JD to confirm or deny the request. The chosen option will be stored according to the host header. I've added a host header to prevent confirmation popups on every link send to JD through MediathekView.