### PR TITLE
Website url to pyload and doubled separators in context menu

### DIFF
--- a/src/main/java/mediathek/gui/tabs/tab_film/GuiFilme.java
+++ b/src/main/java/mediathek/gui/tabs/tab_film/GuiFilme.java
@@ -1426,6 +1426,7 @@ public class GuiFilme extends AGuiTabPanel {
             submenueBlack.add(itemBlackSenderThema);
 
             res.ifPresent(film -> {
+                jPopupMenu.addSeparator();
                 jDownloadHelper.installContextMenu(film, jPopupMenu);
                 jPopupMenu.addSeparator();
                 pyLoadHelper.installContextMenu(film, jPopupMenu);

--- a/src/main/java/mediathek/gui/tabs/tab_film/PyLoadHelper.kt
+++ b/src/main/java/mediathek/gui/tabs/tab_film/PyLoadHelper.kt
@@ -119,22 +119,6 @@ class PyLoadHelper {
             mJD.add(miLow)
         }
         jPopupMenu.add(mJD)
-
-        val miWebsiteToJd = JMenuItem("Webseiten-URL an pyLoad übergeben")
-        miWebsiteToJd.isEnabled = pyLoadConfigured
-        miWebsiteToJd.addActionListener {
-            try {
-                val webSiteUrl = film.websiteUrl.toHttpUrl()
-                downloadUrl(webSiteUrl, film)
-            }
-            catch (_: IllegalArgumentException) {
-                logger.error("Illegal Website URL found: {}", film.websiteUrl)
-            }
-        }
-        jPopupMenu.add(miWebsiteToJd)
-        if (film.websiteUrl.isBlank()) {
-            miWebsiteToJd.isEnabled = false
-        }
     }
 
     companion object {

--- a/src/main/java/mediathek/gui/tabs/tab_film/PyLoadHelper.kt
+++ b/src/main/java/mediathek/gui/tabs/tab_film/PyLoadHelper.kt
@@ -92,8 +92,6 @@ class PyLoadHelper {
     }
 
     fun installContextMenu(film: DatenFilm, jPopupMenu: JPopupMenu) {
-        jPopupMenu.addSeparator()
-
         val pyLoadUrl = ApplicationConfiguration.getConfiguration()
             .getString(ApplicationConfiguration.APPLICATION_PYLOAD_URL, "")
         val pyLoadConfigured = pyLoadUrl.isNotBlank()

--- a/src/main/kotlin/mediathek/gui/tabs/tab_film/JDownloadHelper.kt
+++ b/src/main/kotlin/mediathek/gui/tabs/tab_film/JDownloadHelper.kt
@@ -70,8 +70,6 @@ class JDownloadHelper {
     }
 
     fun installContextMenu(film: DatenFilm, jPopupMenu: JPopupMenu) {
-        jPopupMenu.addSeparator()
-
         val mJD = JMenu("Mit JDownloader herunterladen")
         val uNormal = film.urlNormalQuality.toHttpUrl()
         val uHq = film.getUrlFuerAufloesung(FilmResolution.Enum.HIGH_QUALITY).toHttpUrl()


### PR DESCRIPTION
Removed website-url to pyload menu entry (I must have tested this feature wrongly, when adding it.)
Corrected doubled shown menu separators in context menu.