### PR TITLE
Set higher minimum memory threshold

### DIFF
--- a/src/main/java/mediathek/Main.java
+++ b/src/main/java/mediathek/Main.java
@@ -798,7 +798,7 @@ public class Main {
         final var maxMem = Runtime.getRuntime().maxMemory();
         if (maxMem < Konstanten.MINIMUM_MEMORY_THRESHOLD) {
             JOptionPane.showMessageDialog(null,
-                    "Es werden mindestens 768MB RAM zum Betrieb benötigt.\n" +
+                    "Es werden mindestens 1280MB RAM zum Betrieb benötigt.\n" +
                             "Das Programm wird nun beendet.",
                     Konstanten.PROGRAMMNAME, JOptionPane.ERROR_MESSAGE);
 

--- a/src/main/java/mediathek/config/Konstanten.java
+++ b/src/main/java/mediathek/config/Konstanten.java
@@ -29,7 +29,7 @@ public class Konstanten {
     public static final String ZAPP_API_URL = "https://api.zapp.mediathekview.de/";
     public static final String NEW_SENDER_ACTIVATED_QUESTION_CONFIG_KEY = "newSendersActivated.fourteen.three";
     public static final String NEW_FILMLENGTH_ACTIVATED_QUESTION_CONFIG_KEY = "newFilmlengthActivated.fourteen.three";
-    public static final long MINIMUM_MEMORY_THRESHOLD = 768 * FileUtils.ONE_MB;
+    public static final long MINIMUM_MEMORY_THRESHOLD = 1280 * FileUtils.ONE_MB;
     public static final Version MVVERSION = new Version(14, 5, 0);
 
     public static final ApplicationType APPLICATION_TYPE = ApplicationType.PRODUCTION;


### PR DESCRIPTION
I tested the application with low memory, but 768 MB is not enough to run the current version, it always run out of memory after launch. 1280 MB is needed at least.