### PR TITLE
Add headless CLI and API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ res/Icons/Sender
 deploy.key
 RepoZugang.properties
 /target/
+/headless/target/
 /dependency-reduced-pom.xml
 *.iml
 /install4j*/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# MediathekView
+
+This fork adds the standalone Java headless client under `headless/`. Read
+`../CLAUDE.md` and `/home/janosch/DEV/CLAUDE.md` for workspace-wide rules.
+
+## Live headless instance
+
+- Host: `minipc-china-01` (Ubuntu; LAN `10.9.0.100`, OS hostname may be
+  `19minipc`), running in the China/Dev site timezone (`Asia/Shanghai`).
+- Remote access: use the `meshcentral` skill and the `minipc-china-01` node in
+  MeshCentral group `Dev`. Direct SSH to `admin@10.9.0.100` works only when the
+  Dev LAN is reachable; do not assume it is available remotely.
+- JAR: `/opt/mediathekview-headless/mediathekview-headless.jar`
+- configuration: `/etc/mediathekview-headless/subscriptions.json`
+- SQLite state/history: `/var/lib/mediathekview-headless/history.db`
+- media library: `/mnt/nas-china-01/Kinder/Video/Mediathek`
+- service account: `admin`
+
+The API is `mediathekview-headless-api.service`. It listens without
+authentication on loopback only at `http://127.0.0.1:7070`; never expose it
+directly to an untrusted network. It requires the
+`/mnt/nas-china-01/Kinder` NAS mount and has write access only to its state and
+media-library paths.
+
+`mediathekview-headless-sync.timer` queues `POST /api/sync` hourly with up to
+five minutes of randomized delay. The API owns a single download worker, so
+timer and manual work remain serialized. The checked-in unit sources are in
+`headless/systemd/`; API usage and deployment assumptions are documented in
+`headless/README.md`.
+
+## Read-only status checks
+
+Run these on `minipc-china-01` through MeshCentral or an existing SSH session:
+
+```bash
+systemctl status mediathekview-headless-api.service \
+  mediathekview-headless-sync.timer --no-pager -l
+systemctl list-timers mediathekview-headless-sync.timer --no-pager
+curl --fail --silent --show-error http://127.0.0.1:7070/health
+curl --fail --silent --show-error http://127.0.0.1:7070/api/downloads
+journalctl -u mediathekview-headless-api.service \
+  -u mediathekview-headless-sync.service --since "24 hours ago" --no-pager
+df -h /var/lib/mediathekview-headless /mnt/nas-china-01/Kinder
+```
+
+The sync oneshot exiting successfully means its request was queued, not that
+all downloads finished. Use `/api/downloads` to confirm final download states.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ sudo rpm --import https://download.mediathekview.de/stabil/MediathekView-rpm-sig
 # Bedienung
 Siehe [Anleitung](https://mediathekview.de/anleitung/)
 
+## Headless / Kommandozeile
+
+Der eigenständige Java-17-Client unter [`headless/`](headless/) bietet Suche,
+Downloads, Abonnements und eine lokale HTTP-API ohne grafische Sitzung. Die
+Desktop-Anwendung bleibt davon unabhängig.
+
 # Support
 Bei Fragen, Hilfe, gesuchten Sendungen oder sonstigen bitte das [Forum](https://forum.mediathekview.de/) verwenden.
 

--- a/headless/README.md
+++ b/headless/README.md
@@ -63,21 +63,44 @@ java -jar headless/target/mediathekview-headless.jar \
 java -jar headless/target/mediathekview-headless.jar \
   --state /var/lib/mediathekview-headless/history.db \
   sync --config /etc/mediathekview-headless/subscriptions.json
+
+java -jar headless/target/mediathekview-headless.jar \
+  --state /var/lib/mediathekview-headless/history.db \
+  sync --config /etc/mediathekview-headless/subscriptions.json --dry-run
 ```
 
 ## Subscriptions
 
 Copy [`subscriptions.example.json`](subscriptions.example.json), set an
 existing `outputDirectory`, and add one or more rules. Query clauses inside a
-subscription are combined with AND. A clause can search `channel`, `topic`,
-`title`, and/or `description`.
+subscription use MediathekViewWeb's field-grouping behavior. Put words that
+must all occur in the same field into one clause, such as `Anna Haustiere`.
+Separate clauses targeting the same field can behave as alternatives. A clause
+can search `channel`, `topic`, `title`, and/or `description`.
 
 `maxResults` limits the newest matches considered in one run and defaults to
 10. Matching entries are downloaded oldest-first within that window. The
 history database makes later runs idempotent.
 
-Run the file once with `sync` before enabling a timer. An empty history means
-the first run downloads all matching entries in the configured result window.
+Optional case-insensitive regular-expression filters are applied after the
+catalog query and before `maxResults`:
+
+- `includeTitleRegex` and `excludeTitleRegex`
+- `includeTopicRegex` and `excludeTopicRegex`
+
+The client pages through catalog results until it has found `maxResults`
+entries that pass the filters. This matters for programs such as *Die Sendung
+mit der Maus*, where standard, audio-description, and sign-language editions
+share the same timestamp. Invalid regular expressions are reported as
+subscription errors. Catalog entries that resolve to the same selected media
+URL are treated as one item within a subscription, avoiding duplicate ARD/BR
+copies of the same episode.
+
+Run `sync --dry-run` first, then run one ordinary `sync` before enabling a
+timer. A dry run queries the live catalog and checks history without creating
+output directories, downloading media, or writing history rows. An empty
+history means the first ordinary run downloads all matching entries in the
+configured result window.
 
 ## HTTP API
 

--- a/headless/README.md
+++ b/headless/README.md
@@ -1,0 +1,134 @@
+# MediathekView Headless
+
+`mediathekview-headless` provides search, downloads, subscriptions, download
+history, and a local HTTP API without starting Swing, X11, Wayland, or a
+virtual display. It is a standalone Java 17 application and does not change
+the existing MediathekView desktop entry point.
+
+Searches and exact entry lookups use the current MediathekViewWeb API. Media
+is downloaded from the broadcaster URL returned for the selected entry.
+Progressive files use Java's HTTP client; HLS playlists use `ffmpeg`.
+
+## Build
+
+Requirements:
+
+- JDK 17 or newer
+- `ffmpeg` at runtime when an entry only provides HLS
+
+From the repository root:
+
+```bash
+JAVA_HOME=/path/to/jdk ./mvnw -f headless/pom.xml clean verify
+java -jar headless/target/mediathekview-headless.jar --help
+```
+
+The fat JAR is `headless/target/mediathekview-headless.jar`.
+
+## CLI
+
+Global options such as `--state` and `--base-url` go before the subcommand.
+
+Search and return human-readable rows:
+
+```bash
+java -jar headless/target/mediathekview-headless.jar \
+  search "Die Sendung mit der Maus" --channel WDR --limit 5
+```
+
+Add `--json` for scripting. Each result has a stable `id`; use it for an
+exact lookup or download:
+
+```bash
+java -jar headless/target/mediathekview-headless.jar \
+  show --id 'ENTRY_ID' --json
+
+java -jar headless/target/mediathekview-headless.jar \
+  download --id 'ENTRY_ID' \
+  --output /mnt/media/MediathekView-Downloads \
+  --subdirectory Maus --quality HD
+```
+
+The output root must already exist and be writable. Downloads are written to
+a partial file in the destination directory and renamed only after success.
+The SQLite history prevents downloading the same entry ID twice. `--force`
+overrides history for a one-off download.
+
+Other commands:
+
+```bash
+java -jar headless/target/mediathekview-headless.jar \
+  --state /var/lib/mediathekview-headless/history.db history --json
+
+java -jar headless/target/mediathekview-headless.jar \
+  --state /var/lib/mediathekview-headless/history.db \
+  sync --config /etc/mediathekview-headless/subscriptions.json
+```
+
+## Subscriptions
+
+Copy [`subscriptions.example.json`](subscriptions.example.json), set an
+existing `outputDirectory`, and add one or more rules. Query clauses inside a
+subscription are combined with AND. A clause can search `channel`, `topic`,
+`title`, and/or `description`.
+
+`maxResults` limits the newest matches considered in one run and defaults to
+10. Matching entries are downloaded oldest-first within that window. The
+history database makes later runs idempotent.
+
+Run the file once with `sync` before enabling a timer. An empty history means
+the first run downloads all matching entries in the configured result window.
+
+## HTTP API
+
+Start the server on loopback:
+
+```bash
+java -jar headless/target/mediathekview-headless.jar \
+  --state /var/lib/mediathekview-headless/history.db \
+  serve --bind 127.0.0.1 --port 7070 \
+  --config /etc/mediathekview-headless/subscriptions.json
+```
+
+Endpoints:
+
+- `GET /health`
+- `POST /api/search` — a MediathekViewWeb search request
+- `POST /api/entries` — JSON array of exact entry IDs
+- `GET /api/downloads` — recent local download history
+- `POST /api/downloads` — queue `{id, subdirectory, quality, subtitles}`
+- `POST /api/sync` — queue one subscription run
+
+Examples:
+
+```bash
+curl --fail --silent --show-error \
+  -H 'Content-Type: application/json' \
+  --data '{"queries":[{"fields":["title","topic"],"query":"Maus"}],"size":5,"future":false}' \
+  http://127.0.0.1:7070/api/search
+
+curl --fail --silent --show-error \
+  -H 'Content-Type: application/json' \
+  --data '{"id":"ENTRY_ID","subdirectory":"Maus","quality":"HD","subtitles":true}' \
+  http://127.0.0.1:7070/api/downloads
+```
+
+The API has no authentication and therefore binds to `127.0.0.1` by default.
+Use SSH port forwarding or place an authenticated reverse proxy in front of
+it; do not bind it to an untrusted network as-is. The complete contract is in
+[`openapi.yaml`](openapi.yaml).
+
+## systemd
+
+Example units are in [`systemd/`](systemd/). They assume:
+
+- JAR: `/opt/mediathekview-headless/mediathekview-headless.jar`
+- config: `/etc/mediathekview-headless/subscriptions.json`
+- state: `/var/lib/mediathekview-headless/history.db`
+- service user: `admin`
+- NAS mount: `/mnt/nas-china-01/Kinder`
+
+The API service requires the NAS mount and is sandboxed with write access only
+to its state directory and the dedicated download directory. The timer calls
+the loopback API hourly, so subscription work stays serialized by the API's
+single download worker.

--- a/headless/README.md
+++ b/headless/README.md
@@ -28,6 +28,8 @@ The fat JAR is `headless/target/mediathekview-headless.jar`.
 ## CLI
 
 Global options such as `--state` and `--base-url` go before the subcommand.
+`--timeout` controls catalog and subtitle requests and the ffmpeg network I/O
+stall timeout. Complete media transfers have a separate six-hour safety cap.
 
 Search and return human-readable rows:
 
@@ -51,10 +53,13 @@ java -jar headless/target/mediathekview-headless.jar \
 
 The output root must already exist and be writable. Downloads are written to
 a partial file in the destination directory and renamed only after success.
-The SQLite history prevents downloading the same entry ID twice. Before a
-download, the output tree is also indexed by normalized episode title so an
-entry already present under an older filename is not downloaded again.
-`--force` overrides both checks for a one-off download.
+The SQLite history prevents downloading the same entry ID twice. New filenames
+carry a fingerprint of the selected media URL. Before a download, the output
+tree is indexed by normalized episode title plus that source identity; legacy
+MediathekView filenames carrying a ten-digit URL hash are recognized too.
+Files without recoverable source identity are not used for deduplication,
+because title-only matching can suppress distinct recurring episodes.
+`--force` overrides the history and library checks for a one-off download.
 
 Other commands:
 
@@ -82,7 +87,8 @@ can search `channel`, `topic`, `title`, and/or `description`.
 
 `maxResults` limits the newest matches considered in one run and defaults to
 10. Matching entries are downloaded oldest-first within that window. The
-history database makes later runs idempotent.
+history database makes later runs idempotent. Subscription names must be
+unique within a config file.
 
 Optional case-insensitive regular-expression filters are applied after the
 catalog query and before `maxResults`:
@@ -97,9 +103,9 @@ share the same timestamp. Invalid regular expressions are reported as
 subscription errors. Catalog entries that resolve to the same selected media
 URL are treated as one item within a subscription, avoiding duplicate ARD/BR
 copies of the same episode. The configured output tree is scanned recursively
-before planning a sync. Existing videos are reported as
-`already-in-library`; dated headless filenames and legacy names ending in a
-ten-digit ID are both recognized.
+before planning a sync. Identity-bearing existing videos are reported as
+`already-in-library`; source-fingerprinted headless filenames and legacy names
+ending in a ten-digit URL hash are both recognized.
 
 Run `sync --dry-run` first, then run one ordinary `sync` before enabling a
 timer. A dry run queries the live catalog and checks history without creating

--- a/headless/README.md
+++ b/headless/README.md
@@ -51,8 +51,10 @@ java -jar headless/target/mediathekview-headless.jar \
 
 The output root must already exist and be writable. Downloads are written to
 a partial file in the destination directory and renamed only after success.
-The SQLite history prevents downloading the same entry ID twice. `--force`
-overrides history for a one-off download.
+The SQLite history prevents downloading the same entry ID twice. Before a
+download, the output tree is also indexed by normalized episode title so an
+entry already present under an older filename is not downloaded again.
+`--force` overrides both checks for a one-off download.
 
 Other commands:
 
@@ -94,7 +96,10 @@ mit der Maus*, where standard, audio-description, and sign-language editions
 share the same timestamp. Invalid regular expressions are reported as
 subscription errors. Catalog entries that resolve to the same selected media
 URL are treated as one item within a subscription, avoiding duplicate ARD/BR
-copies of the same episode.
+copies of the same episode. The configured output tree is scanned recursively
+before planning a sync. Existing videos are reported as
+`already-in-library`; dated headless filenames and legacy names ending in a
+ten-digit ID are both recognized.
 
 Run `sync --dry-run` first, then run one ordinary `sync` before enabling a
 timer. A dry run queries the live catalog and checks history without creating
@@ -152,6 +157,6 @@ Example units are in [`systemd/`](systemd/). They assume:
 - NAS mount: `/mnt/nas-china-01/Kinder`
 
 The API service requires the NAS mount and is sandboxed with write access only
-to its state directory and the dedicated download directory. The timer calls
+to its state directory and the configured media library. The timer calls
 the loopback API hourly, so subscription work stays serialized by the API's
 single download worker.

--- a/headless/openapi.yaml
+++ b/headless/openapi.yaml
@@ -1,0 +1,134 @@
+openapi: 3.1.0
+info:
+  title: MediathekView Headless API
+  version: 0.1.0
+  description: Local search and download API. It has no built-in authentication.
+servers:
+  - url: http://127.0.0.1:7070
+paths:
+  /health:
+    get:
+      operationId: health
+      responses:
+        '200':
+          description: Service is ready.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: {type: string, const: ok}
+  /api/search:
+    post:
+      operationId: search
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/SearchRequest'}
+      responses:
+        '200':
+          description: Search result.
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/SearchResult'}
+  /api/entries:
+    post:
+      operationId: entries
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items: {type: string}
+      responses:
+        '200':
+          description: Exact entries that still exist in the current film list.
+  /api/downloads:
+    get:
+      operationId: downloadHistory
+      responses:
+        '200': {description: Up to 100 recent download-history rows.}
+    post:
+      operationId: queueDownload
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/DownloadRequest'}
+      responses:
+        '202': {description: Download queued.}
+        '409': {description: Server has no configured output directory.}
+  /api/sync:
+    post:
+      operationId: queueSubscriptionSync
+      responses:
+        '202': {description: Subscription sync queued.}
+        '409': {description: Server was started without a subscription config.}
+components:
+  schemas:
+    QueryClause:
+      type: object
+      required: [fields, query]
+      properties:
+        fields:
+          type: array
+          items:
+            type: string
+            enum: [channel, topic, title, description]
+        query: {type: string}
+    SearchRequest:
+      type: object
+      properties:
+        queries:
+          type: array
+          items: {$ref: '#/components/schemas/QueryClause'}
+        sortBy:
+          type: string
+          enum: [timestamp, duration, channel, topic, title]
+          default: timestamp
+        sortOrder:
+          type: string
+          enum: [asc, desc]
+          default: desc
+        future: {type: boolean, default: false}
+        offset: {type: integer, minimum: 0, default: 0}
+        size: {type: integer, minimum: 1, maximum: 1000, default: 15}
+        duration_min: {type: integer, minimum: 0}
+        duration_max: {type: integer, minimum: 0}
+    Film:
+      type: object
+      required: [id, channel, topic, title, timestamp]
+      properties:
+        id: {type: string}
+        channel: {type: string}
+        topic: {type: string}
+        title: {type: string}
+        description: {type: string}
+        timestamp: {type: integer, format: int64}
+        duration: {type: integer}
+        size: {type: integer, format: int64}
+        url_website: {type: string}
+        url_subtitle: {type: string}
+        url_video: {type: string}
+        url_video_low: {type: string}
+        url_video_hd: {type: string}
+    SearchResult:
+      type: object
+      properties:
+        results:
+          type: array
+          items: {$ref: '#/components/schemas/Film'}
+        queryInfo: {type: object, additionalProperties: true}
+    DownloadRequest:
+      type: object
+      required: [id]
+      properties:
+        id: {type: string}
+        subdirectory: {type: string}
+        quality:
+          type: string
+          enum: [HD, SD, LOW]
+          default: HD
+        subtitles: {type: boolean, default: true}

--- a/headless/pom.xml
+++ b/headless/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>de.mediathekview</groupId>
+    <artifactId>mediathekview-headless</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <name>MediathekView Headless</name>
+    <description>Command-line and HTTP API client for MediathekView</description>
+    <url>https://github.com/mediathekview/MediathekView</url>
+
+    <licenses>
+        <license>
+            <name>GNU General Public License version 3.0</name>
+            <url>https://www.gnu.org/licenses/gpl-3.0.txt</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>17</maven.compiler.release>
+        <jackson.version>2.20.0</jackson.version>
+        <junit.version>6.0.3</junit.version>
+        <picocli.version>4.7.7</picocli.version>
+        <sqlite.version>3.51.2.0</sqlite.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <version>${picocli.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>${sqlite.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.1</version>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>info.picocli</groupId>
+                            <artifactId>picocli-codegen</artifactId>
+                            <version>${picocli.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <finalName>mediathekview-headless</finalName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>mediathek.headless.HeadlessMain</mainClass>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/headless/src/main/java/mediathek/headless/DownloadService.java
+++ b/headless/src/main/java/mediathek/headless/DownloadService.java
@@ -10,6 +10,7 @@ package mediathek.headless;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -81,10 +82,11 @@ final class DownloadService {
             return null;
         }
 
-        String sourceUrl = quality.selectUrl(film);
-        if (sourceUrl.isBlank()) {
+        String selectedUrl = quality.selectUrl(film);
+        if (selectedUrl.isBlank()) {
             throw new IOException("Entry has no downloadable video URL: " + film.id());
         }
+        String sourceUrl = normalizeMediaUrl(selectedUrl, film.id());
 
         String subdirectory = requestedSubdirectory == null || requestedSubdirectory.isBlank()
                 ? film.topic()
@@ -245,7 +247,8 @@ final class DownloadService {
         return output.isBlank() ? "" : ": " + output;
     }
 
-    private void downloadSubtitle(String sourceUrl, Path videoPath) throws IOException, InterruptedException {
+    private void downloadSubtitle(String rawUrl, Path videoPath) throws IOException, InterruptedException {
+        String sourceUrl = normalizeMediaUrl(rawUrl, "subtitle");
         String extension = subtitleExtension(sourceUrl);
         Path destination = replaceExtension(videoPath, extension);
         Path partial = destination.resolveSibling(destination.getFileName() + ".part");
@@ -282,8 +285,38 @@ final class DownloadService {
         throw new FileAlreadyExistsException(withId.toString());
     }
 
+    /**
+     * MediathekViewWeb occasionally serves scheme-relative URLs ({@code //host/path}), which
+     * {@link HttpRequest.Builder#uri} rejects with "URI with undefined scheme". Resolve those
+     * against HTTPS and reject anything the downloader cannot fetch, so a bad entry fails with a
+     * message that names the offending URL.
+     */
+    static String normalizeMediaUrl(String url, String context) throws IOException {
+        String candidate = url.trim();
+        if (candidate.startsWith("//")) {
+            candidate = "https:" + candidate;
+        }
+        URI parsed;
+        try {
+            parsed = new URI(candidate);
+        }
+        catch (URISyntaxException exception) {
+            throw new IOException("Entry has a malformed video URL (" + context + "): " + url, exception);
+        }
+        String scheme = parsed.getScheme();
+        if (scheme == null || !(scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"))) {
+            throw new IOException("Entry has an unsupported video URL scheme (" + context + "): " + url);
+        }
+        return candidate;
+    }
+
+    private static String urlPath(String url) {
+        String path = URI.create(url).getPath();
+        return path == null ? "" : path.toLowerCase();
+    }
+
     private static String chooseExtension(String url) {
-        String path = URI.create(url).getPath().toLowerCase();
+        String path = urlPath(url);
         if (path.endsWith(".webm")) {
             return ".webm";
         }
@@ -294,7 +327,7 @@ final class DownloadService {
     }
 
     private static String subtitleExtension(String url) {
-        String path = URI.create(url).getPath().toLowerCase();
+        String path = urlPath(url);
         if (path.endsWith(".vtt")) {
             return ".vtt";
         }
@@ -312,7 +345,7 @@ final class DownloadService {
     }
 
     private static boolean isHls(String url) {
-        return URI.create(url).getPath().toLowerCase().endsWith(".m3u8");
+        return urlPath(url).endsWith(".m3u8");
     }
 
     private static String shortId(String id) {

--- a/headless/src/main/java/mediathek/headless/DownloadService.java
+++ b/headless/src/main/java/mediathek/headless/DownloadService.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2026 MediathekView contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package mediathek.headless;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.HexFormat;
+
+import static mediathek.headless.Model.Film;
+import static mediathek.headless.Model.Quality;
+
+final class DownloadService {
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+            .withZone(ZoneOffset.UTC);
+    private static final int MAX_FILENAME_LENGTH = 180;
+
+    private final HistoryStore history;
+    private final HttpClient httpClient;
+    private final Duration timeout;
+
+    DownloadService(HistoryStore history, Duration timeout) {
+        this(history, timeout, HttpClient.newBuilder()
+                .connectTimeout(timeout)
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .build());
+    }
+
+    DownloadService(HistoryStore history, Duration timeout, HttpClient httpClient) {
+        this.history = history;
+        this.timeout = timeout;
+        this.httpClient = httpClient;
+    }
+
+    Path download(Film film, Path outputRoot, String requestedSubdirectory, Quality quality,
+                  boolean subtitles, boolean force) throws Exception {
+        if (!force && history.isCompleted(film.id())) {
+            return null;
+        }
+        Path normalizedOutputRoot = outputRoot.toAbsolutePath().normalize();
+        requireOutputRoot(normalizedOutputRoot);
+
+        String sourceUrl = quality.selectUrl(film);
+        if (sourceUrl.isBlank()) {
+            throw new IOException("Entry has no downloadable video URL: " + film.id());
+        }
+
+        String subdirectory = requestedSubdirectory == null || requestedSubdirectory.isBlank()
+                ? film.topic()
+                : requestedSubdirectory;
+        Path destinationDirectory = normalizedOutputRoot.resolve(sanitizePathSegment(subdirectory)).normalize();
+        if (!destinationDirectory.startsWith(normalizedOutputRoot)) {
+            throw new IOException("Download directory escaped the configured output root");
+        }
+        Files.createDirectories(destinationDirectory);
+
+        String extension = chooseExtension(sourceUrl);
+        String date = DATE_FORMAT.format(Instant.ofEpochSecond(film.timestamp()));
+        String baseName = sanitizePathSegment(date + " - " + film.title());
+        Path destination = uniqueDestination(destinationDirectory, baseName, extension, film.id());
+        Path partial = destination.resolveSibling(destination.getFileName() + ".part" + extension);
+
+        history.begin(film, quality, destination, sourceUrl);
+        try {
+            Files.deleteIfExists(partial);
+            if (isHls(sourceUrl)) {
+                downloadHls(sourceUrl, partial);
+            }
+            else {
+                downloadHttp(sourceUrl, partial);
+            }
+            if (Files.size(partial) == 0) {
+                throw new IOException("Downloaded file is empty");
+            }
+            moveCompleted(partial, destination);
+
+            if (subtitles && film.subtitleUrl() != null && !film.subtitleUrl().isBlank()) {
+                try {
+                    downloadSubtitle(film.subtitleUrl(), destination);
+                }
+                catch (Exception subtitleError) {
+                    System.err.println("Subtitle download failed for " + film.id() + ": " + subtitleError.getMessage());
+                }
+            }
+            history.complete(film.id(), destination);
+            return destination;
+        }
+        catch (Exception exception) {
+            try {
+                Files.deleteIfExists(partial);
+            }
+            catch (IOException cleanupError) {
+                exception.addSuppressed(cleanupError);
+            }
+            history.fail(film.id(), exception);
+            throw exception;
+        }
+    }
+
+    static String sanitizePathSegment(String value) {
+        String sanitized = value == null ? "download" : value
+                .replaceAll("[\\p{Cntrl}/\\\\:*?\"<>|]", "_")
+                .replaceAll("\\s+", " ")
+                .trim()
+                .replaceAll("[. ]+$", "");
+        if (sanitized.isBlank() || sanitized.equals(".") || sanitized.equals("..")) {
+            sanitized = "download";
+        }
+        if (sanitized.length() > MAX_FILENAME_LENGTH) {
+            sanitized = sanitized.substring(0, MAX_FILENAME_LENGTH).trim();
+        }
+        return sanitized;
+    }
+
+    private void requireOutputRoot(Path outputRoot) throws IOException {
+        Path absolute = outputRoot.toAbsolutePath().normalize();
+        if (!Files.isDirectory(absolute)) {
+            throw new IOException("Output root must already exist: " + absolute);
+        }
+        if (!Files.isWritable(absolute)) {
+            throw new IOException("Output root is not writable: " + absolute);
+        }
+    }
+
+    private void downloadHttp(String sourceUrl, Path partial) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder(URI.create(sourceUrl))
+                .timeout(Duration.ofHours(6))
+                .header("User-Agent", "MediathekView-Headless/0.1")
+                .GET()
+                .build();
+        HttpResponse<Path> response = httpClient.send(request, HttpResponse.BodyHandlers.ofFile(partial));
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new IOException("Video server returned HTTP " + response.statusCode());
+        }
+    }
+
+    private void downloadHls(String sourceUrl, Path partial) throws IOException, InterruptedException {
+        Process process;
+        try {
+            process = new ProcessBuilder(
+                    "ffmpeg", "-hide_banner", "-loglevel", "error", "-nostdin", "-y",
+                    "-i", sourceUrl, "-c", "copy", partial.toString())
+                    .redirectErrorStream(true)
+                    .start();
+        }
+        catch (IOException exception) {
+            throw new IOException("ffmpeg is required for HLS downloads", exception);
+        }
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        int exitCode = process.waitFor();
+        if (exitCode != 0) {
+            throw new IOException("ffmpeg failed with exit code " + exitCode + ": " + output.trim());
+        }
+    }
+
+    private void downloadSubtitle(String sourceUrl, Path videoPath) throws IOException, InterruptedException {
+        String extension = subtitleExtension(sourceUrl);
+        Path destination = replaceExtension(videoPath, extension);
+        Path partial = destination.resolveSibling(destination.getFileName() + ".part");
+        try {
+            HttpRequest request = HttpRequest.newBuilder(URI.create(sourceUrl))
+                    .timeout(timeout)
+                    .header("User-Agent", "MediathekView-Headless/0.1")
+                    .GET()
+                    .build();
+            HttpResponse<Path> response = httpClient.send(request, HttpResponse.BodyHandlers.ofFile(partial));
+            if (response.statusCode() >= 200 && response.statusCode() < 300 && Files.size(partial) > 0) {
+                moveCompleted(partial, destination);
+            }
+            else {
+                Files.deleteIfExists(partial);
+            }
+        }
+        catch (IllegalArgumentException exception) {
+            Files.deleteIfExists(partial);
+        }
+    }
+
+    private static Path uniqueDestination(Path directory, String baseName, String extension, String id)
+            throws IOException {
+        Path preferred = directory.resolve(baseName + extension);
+        if (!Files.exists(preferred)) {
+            return preferred;
+        }
+        String suffix = shortId(id);
+        Path withId = directory.resolve(baseName + " [" + suffix + "]" + extension);
+        if (!Files.exists(withId)) {
+            return withId;
+        }
+        throw new FileAlreadyExistsException(withId.toString());
+    }
+
+    private static String chooseExtension(String url) {
+        String path = URI.create(url).getPath().toLowerCase();
+        if (path.endsWith(".webm")) {
+            return ".webm";
+        }
+        if (path.endsWith(".mkv")) {
+            return ".mkv";
+        }
+        return ".mp4";
+    }
+
+    private static String subtitleExtension(String url) {
+        String path = URI.create(url).getPath().toLowerCase();
+        if (path.endsWith(".vtt")) {
+            return ".vtt";
+        }
+        if (path.endsWith(".srt")) {
+            return ".srt";
+        }
+        return ".ttml";
+    }
+
+    private static Path replaceExtension(Path path, String extension) {
+        String name = path.getFileName().toString();
+        int dot = name.lastIndexOf('.');
+        String withoutExtension = dot > 0 ? name.substring(0, dot) : name;
+        return path.resolveSibling(withoutExtension + extension);
+    }
+
+    private static boolean isHls(String url) {
+        return URI.create(url).getPath().toLowerCase().endsWith(".m3u8");
+    }
+
+    private static String shortId(String id) {
+        byte[] bytes = id.getBytes(StandardCharsets.UTF_8);
+        return HexFormat.of().formatHex(bytes, 0, Math.min(bytes.length, 4));
+    }
+
+    private static void moveCompleted(Path source, Path destination) throws IOException {
+        try {
+            Files.move(source, destination, StandardCopyOption.ATOMIC_MOVE);
+        }
+        catch (IOException exception) {
+            Files.move(source, destination);
+        }
+    }
+}

--- a/headless/src/main/java/mediathek/headless/DownloadService.java
+++ b/headless/src/main/java/mediathek/headless/DownloadService.java
@@ -23,6 +23,8 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.HexFormat;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static mediathek.headless.Model.Film;
 import static mediathek.headless.Model.Quality;
@@ -31,10 +33,14 @@ final class DownloadService {
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd")
             .withZone(ZoneOffset.UTC);
     private static final int MAX_FILENAME_LENGTH = 180;
+    private static final Duration MEDIA_TRANSFER_TIMEOUT = Duration.ofHours(6);
+    private static final Duration PROCESS_TERMINATION_GRACE = Duration.ofSeconds(2);
 
     private final HistoryStore history;
     private final HttpClient httpClient;
     private final Duration timeout;
+    private final Duration mediaTransferTimeout;
+    private final ProcessLauncher processLauncher;
 
     DownloadService(HistoryStore history, Duration timeout) {
         this(history, timeout, HttpClient.newBuilder()
@@ -44,9 +50,16 @@ final class DownloadService {
     }
 
     DownloadService(HistoryStore history, Duration timeout, HttpClient httpClient) {
+        this(history, timeout, httpClient, MEDIA_TRANSFER_TIMEOUT, ProcessBuilder::start);
+    }
+
+    DownloadService(HistoryStore history, Duration timeout, HttpClient httpClient,
+                    Duration mediaTransferTimeout, ProcessLauncher processLauncher) {
         this.history = history;
         this.timeout = timeout;
         this.httpClient = httpClient;
+        this.mediaTransferTimeout = mediaTransferTimeout;
+        this.processLauncher = processLauncher;
     }
 
     Path download(Film film, Path outputRoot, String requestedSubdirectory, Quality quality,
@@ -84,7 +97,8 @@ final class DownloadService {
 
         String extension = chooseExtension(sourceUrl);
         String date = DATE_FORMAT.format(Instant.ofEpochSecond(film.timestamp()));
-        String baseName = sanitizePathSegment(date + " - " + film.title());
+        String baseName = sanitizePathSegment(date + " - " + film.title())
+                + " [src-" + EpisodeIdentity.sourceFingerprint(sourceUrl) + "]";
         Path destination = uniqueDestination(destinationDirectory, baseName, extension, film.id());
         Path partial = destination.resolveSibling(destination.getFileName() + ".part" + extension);
 
@@ -155,7 +169,7 @@ final class DownloadService {
 
     private void downloadHttp(String sourceUrl, Path partial) throws IOException, InterruptedException {
         HttpRequest request = HttpRequest.newBuilder(URI.create(sourceUrl))
-                .timeout(Duration.ofHours(6))
+                .timeout(mediaTransferTimeout)
                 .header("User-Agent", "MediathekView-Headless/0.1")
                 .GET()
                 .build();
@@ -166,22 +180,69 @@ final class DownloadService {
     }
 
     private void downloadHls(String sourceUrl, Path partial) throws IOException, InterruptedException {
-        Process process;
+        Path log = Files.createTempFile(partial.getParent(), ".ffmpeg-", ".log");
+        Process process = null;
         try {
-            process = new ProcessBuilder(
+            long ioTimeoutMicros = Math.max(1, timeout.toNanos() / 1_000);
+            List<String> command = List.of(
                     "ffmpeg", "-hide_banner", "-loglevel", "error", "-nostdin", "-y",
-                    "-i", sourceUrl, "-c", "copy", partial.toString())
+                    "-rw_timeout", Long.toString(ioTimeoutMicros),
+                    "-i", sourceUrl, "-c", "copy", partial.toString());
+            ProcessBuilder builder = new ProcessBuilder(command)
                     .redirectErrorStream(true)
-                    .start();
+                    .redirectOutput(ProcessBuilder.Redirect.to(log.toFile()));
+            try {
+                process = processLauncher.start(builder);
+            }
+            catch (IOException exception) {
+                throw new IOException("ffmpeg is required for HLS downloads", exception);
+            }
+
+            boolean finished;
+            try {
+                finished = process.waitFor(Math.max(1, mediaTransferTimeout.toMillis()), TimeUnit.MILLISECONDS);
+            }
+            catch (InterruptedException exception) {
+                process.destroyForcibly();
+                Thread.currentThread().interrupt();
+                throw exception;
+            }
+            if (!finished) {
+                terminate(process);
+                String output = Files.readString(log, StandardCharsets.UTF_8).trim();
+                throw new IOException("ffmpeg timed out after " + mediaTransferTimeout
+                        + formatProcessOutput(output));
+            }
+
+            String output = Files.readString(log, StandardCharsets.UTF_8);
+            int exitCode = process.exitValue();
+            if (exitCode != 0) {
+                throw new IOException("ffmpeg failed with exit code " + exitCode + ": " + output.trim());
+            }
         }
-        catch (IOException exception) {
-            throw new IOException("ffmpeg is required for HLS downloads", exception);
+        finally {
+            if (process != null && process.isAlive()) {
+                process.destroyForcibly();
+            }
+            try {
+                Files.deleteIfExists(log);
+            }
+            catch (IOException exception) {
+                System.err.println("Could not remove ffmpeg log " + log + ": " + exception.getMessage());
+            }
         }
-        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-        int exitCode = process.waitFor();
-        if (exitCode != 0) {
-            throw new IOException("ffmpeg failed with exit code " + exitCode + ": " + output.trim());
+    }
+
+    private static void terminate(Process process) throws InterruptedException {
+        process.destroy();
+        if (!process.waitFor(PROCESS_TERMINATION_GRACE.toMillis(), TimeUnit.MILLISECONDS)) {
+            process.destroyForcibly();
+            process.waitFor(PROCESS_TERMINATION_GRACE.toMillis(), TimeUnit.MILLISECONDS);
         }
+    }
+
+    private static String formatProcessOutput(String output) {
+        return output.isBlank() ? "" : ": " + output;
     }
 
     private void downloadSubtitle(String sourceUrl, Path videoPath) throws IOException, InterruptedException {
@@ -266,5 +327,10 @@ final class DownloadService {
         catch (IOException exception) {
             Files.move(source, destination);
         }
+    }
+
+    @FunctionalInterface
+    interface ProcessLauncher {
+        Process start(ProcessBuilder builder) throws IOException;
     }
 }

--- a/headless/src/main/java/mediathek/headless/DownloadService.java
+++ b/headless/src/main/java/mediathek/headless/DownloadService.java
@@ -51,11 +51,22 @@ final class DownloadService {
 
     Path download(Film film, Path outputRoot, String requestedSubdirectory, Quality quality,
                   boolean subtitles, boolean force) throws Exception {
+        Path normalizedOutputRoot = outputRoot.toAbsolutePath().normalize();
+        requireOutputRoot(normalizedOutputRoot);
+        LibraryIndex library = force ? null : LibraryIndex.scan(normalizedOutputRoot);
+        return download(film, normalizedOutputRoot, requestedSubdirectory, quality, subtitles, force, library);
+    }
+
+    Path download(Film film, Path outputRoot, String requestedSubdirectory, Quality quality,
+                  boolean subtitles, boolean force, LibraryIndex library) throws Exception {
         if (!force && history.isCompleted(film.id())) {
             return null;
         }
         Path normalizedOutputRoot = outputRoot.toAbsolutePath().normalize();
         requireOutputRoot(normalizedOutputRoot);
+        if (!force && library != null && library.find(film).isPresent()) {
+            return null;
+        }
 
         String sourceUrl = quality.selectUrl(film);
         if (sourceUrl.isBlank()) {
@@ -100,6 +111,9 @@ final class DownloadService {
                 }
             }
             history.complete(film.id(), destination);
+            if (library != null) {
+                library.add(destination);
+            }
             return destination;
         }
         catch (Exception exception) {

--- a/headless/src/main/java/mediathek/headless/EpisodeIdentity.java
+++ b/headless/src/main/java/mediathek/headless/EpisodeIdentity.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 MediathekView contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package mediathek.headless;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+final class EpisodeIdentity {
+    private static final int SOURCE_FINGERPRINT_BYTES = 16;
+
+    private EpisodeIdentity() {
+    }
+
+    static String sourceFingerprint(String sourceUrl) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(sourceUrl.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest, 0, SOURCE_FINGERPRINT_BYTES);
+        }
+        catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 is unavailable", exception);
+        }
+    }
+
+    static String legacySourceHash(String sourceUrl) {
+        int hash = Math.abs(sourceUrl.hashCode());
+        StringBuilder padded = new StringBuilder(Integer.toString(hash));
+        while (padded.length() < 10) {
+            padded.insert(0, '0');
+        }
+        return padded.toString();
+    }
+}

--- a/headless/src/main/java/mediathek/headless/HeadlessHttpServer.java
+++ b/headless/src/main/java/mediathek/headless/HeadlessHttpServer.java
@@ -163,7 +163,8 @@ final class HeadlessHttpServer implements AutoCloseable {
         }
         workExecutor.submit(() -> {
             try {
-                subscriptions.sync(config);
+                var result = subscriptions.sync(config);
+                result.errors().forEach(error -> System.err.println("Subscription sync error: " + error));
             }
             catch (Exception exception) {
                 System.err.println("Subscription sync failed: " + exception.getMessage());

--- a/headless/src/main/java/mediathek/headless/HeadlessHttpServer.java
+++ b/headless/src/main/java/mediathek/headless/HeadlessHttpServer.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2026 MediathekView contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package mediathek.headless;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static mediathek.headless.Model.ApiDownloadRequest;
+import static mediathek.headless.Model.Film;
+import static mediathek.headless.Model.Quality;
+import static mediathek.headless.Model.SearchRequest;
+import static mediathek.headless.Model.SubscriptionConfig;
+
+final class HeadlessHttpServer implements AutoCloseable {
+    private final HttpServer server;
+    private final ExecutorService requestExecutor = Executors.newFixedThreadPool(4);
+    private final ExecutorService workExecutor = Executors.newSingleThreadExecutor();
+    private final CountDownLatch stopped = new CountDownLatch(1);
+    private final MediathekViewWebClient client;
+    private final DownloadService downloads;
+    private final HistoryStore history;
+    private final SubscriptionService subscriptions;
+    private final SubscriptionConfig config;
+    private final Path outputRoot;
+
+    HeadlessHttpServer(String bindAddress, int port,
+                       MediathekViewWebClient client,
+                       DownloadService downloads,
+                       HistoryStore history,
+                       SubscriptionService subscriptions,
+                       SubscriptionConfig config) throws IOException {
+        this.client = client;
+        this.downloads = downloads;
+        this.history = history;
+        this.subscriptions = subscriptions;
+        this.config = config;
+        this.outputRoot = config == null || config.outputDirectory() == null
+                ? null
+                : Path.of(config.outputDirectory()).toAbsolutePath().normalize();
+        server = HttpServer.create(new InetSocketAddress(bindAddress, port), 32);
+        server.setExecutor(requestExecutor);
+        server.createContext("/health", this::health);
+        server.createContext("/api/search", this::search);
+        server.createContext("/api/entries", this::entries);
+        server.createContext("/api/downloads", this::downloads);
+        server.createContext("/api/sync", this::sync);
+    }
+
+    void start() {
+        server.start();
+    }
+
+    void await() throws InterruptedException {
+        stopped.await();
+    }
+
+    private void health(HttpExchange exchange) throws IOException {
+        if (!method(exchange, "GET")) {
+            return;
+        }
+        send(exchange, 200, Map.of("status", "ok"));
+    }
+
+    private void search(HttpExchange exchange) throws IOException {
+        if (!method(exchange, "POST")) {
+            return;
+        }
+        try {
+            SearchRequest request = readBody(exchange, SearchRequest.class);
+            send(exchange, 200, client.search(request));
+        }
+        catch (Exception exception) {
+            sendError(exchange, 502, exception);
+        }
+    }
+
+    private void entries(HttpExchange exchange) throws IOException {
+        if (!method(exchange, "POST")) {
+            return;
+        }
+        try {
+            List<String> ids;
+            try (InputStream input = exchange.getRequestBody()) {
+                ids = JsonSupport.MAPPER.readValue(
+                        input,
+                        JsonSupport.MAPPER.getTypeFactory().constructCollectionType(List.class, String.class));
+            }
+            send(exchange, 200, Map.of("results", client.entries(ids)));
+        }
+        catch (Exception exception) {
+            sendError(exchange, 502, exception);
+        }
+    }
+
+    private void downloads(HttpExchange exchange) throws IOException {
+        if (exchange.getRequestMethod().equalsIgnoreCase("GET")) {
+            try {
+                send(exchange, 200, Map.of("downloads", history.list(100)));
+            }
+            catch (Exception exception) {
+                sendError(exchange, 500, exception);
+            }
+            return;
+        }
+        if (!method(exchange, "POST")) {
+            return;
+        }
+        if (outputRoot == null) {
+            send(exchange, 409, Map.of("error", "Server has no subscription config/outputDirectory"));
+            return;
+        }
+        try {
+            ApiDownloadRequest request = readBody(exchange, ApiDownloadRequest.class);
+            if (request.id() == null || request.id().isBlank()) {
+                send(exchange, 400, Map.of("error", "id is required"));
+                return;
+            }
+            Film film = client.entry(request.id());
+            Quality quality = Quality.parse(request.quality());
+            boolean subtitles = request.subtitles() == null || request.subtitles();
+            workExecutor.submit(() -> {
+                try {
+                    downloads.download(film, outputRoot, request.subdirectory(), quality, subtitles, false);
+                }
+                catch (Exception exception) {
+                    System.err.println("Download failed for " + film.id() + ": " + exception.getMessage());
+                }
+            });
+            send(exchange, 202, Map.of("id", film.id(), "status", "queued"));
+        }
+        catch (IllegalArgumentException exception) {
+            sendError(exchange, 400, exception);
+        }
+        catch (Exception exception) {
+            sendError(exchange, 502, exception);
+        }
+    }
+
+    private void sync(HttpExchange exchange) throws IOException {
+        if (!method(exchange, "POST")) {
+            return;
+        }
+        if (config == null) {
+            send(exchange, 409, Map.of("error", "Server was started without --config"));
+            return;
+        }
+        workExecutor.submit(() -> {
+            try {
+                subscriptions.sync(config);
+            }
+            catch (Exception exception) {
+                System.err.println("Subscription sync failed: " + exception.getMessage());
+            }
+        });
+        send(exchange, 202, Map.of("status", "queued"));
+    }
+
+    private static boolean method(HttpExchange exchange, String expected) throws IOException {
+        if (exchange.getRequestMethod().equalsIgnoreCase(expected)) {
+            return true;
+        }
+        exchange.getResponseHeaders().set("Allow", expected);
+        send(exchange, 405, Map.of("error", "Method not allowed"));
+        return false;
+    }
+
+    private static <T> T readBody(HttpExchange exchange, Class<T> type) throws IOException {
+        try (InputStream input = exchange.getRequestBody()) {
+            return JsonSupport.MAPPER.readValue(input, type);
+        }
+    }
+
+    private static void sendError(HttpExchange exchange, int status, Exception exception) throws IOException {
+        String message = exception.getMessage();
+        if (message == null || message.isBlank()) {
+            message = exception.getClass().getSimpleName();
+        }
+        send(exchange, status, Map.of("error", message));
+    }
+
+    private static void send(HttpExchange exchange, int status, Object value) throws IOException {
+        byte[] body = JsonSupport.write(value).getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json; charset=utf-8");
+        exchange.getResponseHeaders().set("Cache-Control", "no-store");
+        exchange.sendResponseHeaders(status, body.length);
+        try (var output = exchange.getResponseBody()) {
+            output.write(body);
+        }
+    }
+
+    @Override
+    public void close() {
+        server.stop(1);
+        workExecutor.shutdownNow();
+        requestExecutor.shutdownNow();
+        stopped.countDown();
+    }
+}

--- a/headless/src/main/java/mediathek/headless/HeadlessHttpServer.java
+++ b/headless/src/main/java/mediathek/headless/HeadlessHttpServer.java
@@ -51,7 +51,9 @@ final class HeadlessHttpServer implements AutoCloseable {
         this.history = history;
         this.subscriptions = subscriptions;
         this.config = config;
-        this.outputRoot = config == null || config.outputDirectory() == null
+        this.outputRoot = config == null
+                || config.outputDirectory() == null
+                || config.outputDirectory().isBlank()
                 ? null
                 : Path.of(config.outputDirectory()).toAbsolutePath().normalize();
         server = HttpServer.create(new InetSocketAddress(bindAddress, port), 32);
@@ -65,6 +67,10 @@ final class HeadlessHttpServer implements AutoCloseable {
 
     void start() {
         server.start();
+    }
+
+    int port() {
+        return server.getAddress().getPort();
     }
 
     void await() throws InterruptedException {

--- a/headless/src/main/java/mediathek/headless/HeadlessMain.java
+++ b/headless/src/main/java/mediathek/headless/HeadlessMain.java
@@ -59,7 +59,7 @@ public final class HeadlessMain implements Runnable {
     @CommandLine.Option(
             names = "--timeout",
             defaultValue = "30",
-            description = "HTTP connection/request timeout in seconds (default: ${DEFAULT-VALUE}).")
+            description = "Network connection/I/O timeout in seconds (default: ${DEFAULT-VALUE}).")
     int timeoutSeconds;
 
     public static void main(String[] args) {

--- a/headless/src/main/java/mediathek/headless/HeadlessMain.java
+++ b/headless/src/main/java/mediathek/headless/HeadlessMain.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright (c) 2026 MediathekView contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package mediathek.headless;
+
+import picocli.CommandLine;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import static mediathek.headless.Model.DownloadRecord;
+import static mediathek.headless.Model.Film;
+import static mediathek.headless.Model.Quality;
+import static mediathek.headless.Model.QueryClause;
+import static mediathek.headless.Model.SearchRequest;
+import static mediathek.headless.Model.SearchResult;
+import static mediathek.headless.Model.SubscriptionConfig;
+import static mediathek.headless.Model.SyncResult;
+
+@CommandLine.Command(
+        name = "mediathekview-headless",
+        description = "Search and download public-broadcast media without a graphical session.",
+        mixinStandardHelpOptions = true,
+        version = "MediathekView Headless 0.1.0",
+        subcommands = {
+                HeadlessMain.SearchCommand.class,
+                HeadlessMain.ShowCommand.class,
+                HeadlessMain.DownloadCommand.class,
+                HeadlessMain.SyncCommand.class,
+                HeadlessMain.HistoryCommand.class,
+                HeadlessMain.ServeCommand.class
+        })
+public final class HeadlessMain implements Runnable {
+    @CommandLine.Option(
+            names = "--base-url",
+            defaultValue = "https://mediathekviewweb.de",
+            description = "MediathekViewWeb base URL (default: ${DEFAULT-VALUE}).")
+    URI baseUrl;
+
+    @CommandLine.Option(
+            names = "--state",
+            defaultValue = "${sys:user.home}/.local/state/mediathekview-headless/history.db",
+            description = "SQLite download-history path (default: ${DEFAULT-VALUE}).")
+    Path statePath;
+
+    @CommandLine.Option(
+            names = "--timeout",
+            defaultValue = "30",
+            description = "HTTP connection/request timeout in seconds (default: ${DEFAULT-VALUE}).")
+    int timeoutSeconds;
+
+    public static void main(String[] args) {
+        CommandLine commandLine = new CommandLine(new HeadlessMain());
+        commandLine.setCaseInsensitiveEnumValuesAllowed(true);
+        int exitCode = commandLine.execute(args);
+        System.exit(exitCode);
+    }
+
+    @Override
+    public void run() {
+        CommandLine.usage(this, System.out);
+    }
+
+    MediathekViewWebClient client() {
+        return new MediathekViewWebClient(baseUrl, timeout());
+    }
+
+    HistoryStore history() throws Exception {
+        return new HistoryStore(statePath);
+    }
+
+    Duration timeout() {
+        return Duration.ofSeconds(Math.max(1, timeoutSeconds));
+    }
+
+    @CommandLine.Command(name = "search", description = "Search the current MediathekView film list.")
+    static final class SearchCommand implements Callable<Integer> {
+        @CommandLine.ParentCommand
+        HeadlessMain parent;
+
+        @CommandLine.Parameters(index = "0", arity = "0..1", paramLabel = "QUERY",
+                description = "Text to match in title or topic.")
+        String query;
+
+        @CommandLine.Option(names = "--channel", description = "Require text in the channel field.")
+        String channel;
+
+        @CommandLine.Option(names = "--topic", description = "Require text in the topic field.")
+        String topic;
+
+        @CommandLine.Option(names = "--title", description = "Require text in the title field.")
+        String title;
+
+        @CommandLine.Option(names = "--description", description = "Require text in the description field.")
+        String description;
+
+        @CommandLine.Option(names = "--min-duration", description = "Minimum duration in seconds.")
+        Integer minDuration;
+
+        @CommandLine.Option(names = "--max-duration", description = "Maximum duration in seconds.")
+        Integer maxDuration;
+
+        @CommandLine.Option(names = "--limit", defaultValue = "20",
+                description = "Maximum results, up to 1000 (default: ${DEFAULT-VALUE}).")
+        int limit;
+
+        @CommandLine.Option(names = "--offset", defaultValue = "0", description = "Result offset.")
+        int offset;
+
+        @CommandLine.Option(names = "--sort", defaultValue = "timestamp",
+                description = "Sort field: timestamp, duration, channel, topic, or title.")
+        String sort;
+
+        @CommandLine.Option(names = "--order", defaultValue = "desc",
+                description = "Sort order: asc or desc.")
+        String order;
+
+        @CommandLine.Option(names = "--future", description = "Include entries scheduled in the future.")
+        boolean future;
+
+        @CommandLine.Option(names = "--json", description = "Print machine-readable JSON.")
+        boolean json;
+
+        @Override
+        public Integer call() throws Exception {
+            SearchResult result = parent.client().search(buildRequest());
+            if (json) {
+                System.out.println(JsonSupport.writePretty(result));
+            }
+            else {
+                printFilms(result.results());
+                System.err.printf("%d of %d result(s)%n", result.results().size(), result.queryInfo().totalResults());
+            }
+            return 0;
+        }
+
+        private SearchRequest buildRequest() {
+            List<QueryClause> clauses = new ArrayList<>();
+            addClause(clauses, List.of("title", "topic"), query);
+            addClause(clauses, List.of("channel"), channel);
+            addClause(clauses, List.of("topic"), topic);
+            addClause(clauses, List.of("title"), title);
+            addClause(clauses, List.of("description"), description);
+            return new SearchRequest(clauses, sort, order, future, offset, limit, minDuration, maxDuration);
+        }
+    }
+
+    @CommandLine.Command(name = "show", description = "Resolve one or more exact entry IDs.")
+    static final class ShowCommand implements Callable<Integer> {
+        @CommandLine.ParentCommand
+        HeadlessMain parent;
+
+        @CommandLine.Option(names = "--id", required = true, arity = "1..*", description = "Entry ID(s).")
+        List<String> ids;
+
+        @CommandLine.Option(names = "--json", description = "Print machine-readable JSON.")
+        boolean json;
+
+        @Override
+        public Integer call() throws Exception {
+            List<Film> films = parent.client().entries(ids);
+            if (json) {
+                System.out.println(JsonSupport.writePretty(films));
+            }
+            else {
+                printFilms(films);
+            }
+            return films.isEmpty() ? 4 : 0;
+        }
+    }
+
+    @CommandLine.Command(name = "download", description = "Download one exact MediathekView entry.")
+    static final class DownloadCommand implements Callable<Integer> {
+        @CommandLine.ParentCommand
+        HeadlessMain parent;
+
+        @CommandLine.Option(names = "--id", required = true, description = "Exact entry ID from search.")
+        String id;
+
+        @CommandLine.Option(names = "--output", required = true,
+                description = "Existing writable output root (a subdirectory is created below it).")
+        Path output;
+
+        @CommandLine.Option(names = "--subdirectory",
+                description = "Folder below the output root (default: entry topic).")
+        String subdirectory;
+
+        @CommandLine.Option(names = "--quality", defaultValue = "HD",
+                description = "Preferred quality: HD, SD, or LOW (default: ${DEFAULT-VALUE}).")
+        Quality quality;
+
+        @CommandLine.Option(names = "--subtitles", negatable = true, defaultValue = "true",
+                description = "Download subtitles when available (default: ${DEFAULT-VALUE}).")
+        boolean subtitles;
+
+        @CommandLine.Option(names = "--force", description = "Download even when the ID is in completed history.")
+        boolean force;
+
+        @Override
+        public Integer call() throws Exception {
+            Film film = parent.client().entry(id);
+            HistoryStore history = parent.history();
+            DownloadService service = new DownloadService(history, parent.timeout());
+            Path path = service.download(film, output.toAbsolutePath().normalize(), subdirectory, quality, subtitles, force);
+            if (path == null) {
+                System.out.println("Already downloaded: " + id);
+            }
+            else {
+                System.out.println(path);
+            }
+            return 0;
+        }
+    }
+
+    @CommandLine.Command(name = "sync", description = "Run all configured subscriptions once.")
+    static final class SyncCommand implements Callable<Integer> {
+        @CommandLine.ParentCommand
+        HeadlessMain parent;
+
+        @CommandLine.Option(names = "--config", required = true, description = "Subscription JSON file.")
+        Path configPath;
+
+        @CommandLine.Option(names = "--json", description = "Print machine-readable JSON.")
+        boolean json;
+
+        @Override
+        public Integer call() throws Exception {
+            SubscriptionConfig config = SubscriptionService.readConfig(configPath);
+            HistoryStore history = parent.history();
+            DownloadService downloads = new DownloadService(history, parent.timeout());
+            SubscriptionService subscriptions = new SubscriptionService(parent.client(), downloads, history);
+            SyncResult result = subscriptions.sync(config);
+            if (json) {
+                System.out.println(JsonSupport.writePretty(result));
+            }
+            else {
+                System.out.printf("subscriptions=%d matched=%d downloaded=%d skipped=%d errors=%d%n",
+                        result.subscriptions(), result.matched(), result.downloaded(), result.skipped(), result.errors().size());
+                result.errors().forEach(error -> System.err.println("ERROR: " + error));
+            }
+            return result.errors().isEmpty() ? 0 : 2;
+        }
+    }
+
+    @CommandLine.Command(name = "history", description = "Show recent download history.")
+    static final class HistoryCommand implements Callable<Integer> {
+        @CommandLine.ParentCommand
+        HeadlessMain parent;
+
+        @CommandLine.Option(names = "--limit", defaultValue = "100", description = "Maximum rows.")
+        int limit;
+
+        @CommandLine.Option(names = "--json", description = "Print machine-readable JSON.")
+        boolean json;
+
+        @Override
+        public Integer call() throws Exception {
+            List<DownloadRecord> records = parent.history().list(limit);
+            if (json) {
+                System.out.println(JsonSupport.writePretty(records));
+            }
+            else {
+                for (DownloadRecord record : records) {
+                    System.out.printf("%-11s  %-20s  %s%n", record.status(), abbreviate(record.id(), 20), record.outputPath());
+                }
+            }
+            return 0;
+        }
+    }
+
+    @CommandLine.Command(name = "serve", description = "Run the local headless HTTP API.")
+    static final class ServeCommand implements Callable<Integer> {
+        @CommandLine.ParentCommand
+        HeadlessMain parent;
+
+        @CommandLine.Option(names = "--bind", defaultValue = "127.0.0.1",
+                description = "Bind address (default: ${DEFAULT-VALUE}). No authentication is provided.")
+        String bind;
+
+        @CommandLine.Option(names = "--port", defaultValue = "7070",
+                description = "Listen port (default: ${DEFAULT-VALUE}).")
+        int port;
+
+        @CommandLine.Option(names = "--config",
+                description = "Subscription JSON; required for API downloads and sync.")
+        Path configPath;
+
+        @Override
+        public Integer call() throws Exception {
+            SubscriptionConfig config = configPath == null ? null : SubscriptionService.readConfig(configPath);
+            HistoryStore history = parent.history();
+            DownloadService downloads = new DownloadService(history, parent.timeout());
+            MediathekViewWebClient client = parent.client();
+            SubscriptionService subscriptions = new SubscriptionService(client, downloads, history);
+            HeadlessHttpServer server = new HeadlessHttpServer(
+                    bind, port, client, downloads, history, subscriptions, config);
+            Runtime.getRuntime().addShutdownHook(new Thread(server::close, "headless-api-shutdown"));
+            server.start();
+            System.out.printf("MediathekView Headless API listening on http://%s:%d%n", bind, port);
+            server.await();
+            return 0;
+        }
+    }
+
+    private static void addClause(List<QueryClause> clauses, List<String> fields, String value) {
+        if (value != null && !value.isBlank()) {
+            clauses.add(new QueryClause(fields, value));
+        }
+    }
+
+    private static void printFilms(List<Film> films) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+                .withZone(ZoneId.systemDefault());
+        for (Film film : films) {
+            System.out.printf("%s  %-8s  %-52s  %s%n",
+                    formatter.format(Instant.ofEpochSecond(film.timestamp())),
+                    abbreviate(film.channel(), 8),
+                    abbreviate(film.title(), 52),
+                    film.id());
+        }
+    }
+
+    private static String abbreviate(String value, int maxLength) {
+        if (value == null) {
+            return "";
+        }
+        if (value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, Math.max(1, maxLength - 1)) + "…";
+    }
+}

--- a/headless/src/main/java/mediathek/headless/HeadlessMain.java
+++ b/headless/src/main/java/mediathek/headless/HeadlessMain.java
@@ -27,6 +27,7 @@ import static mediathek.headless.Model.QueryClause;
 import static mediathek.headless.Model.SearchRequest;
 import static mediathek.headless.Model.SearchResult;
 import static mediathek.headless.Model.SubscriptionConfig;
+import static mediathek.headless.Model.SyncPlan;
 import static mediathek.headless.Model.SyncResult;
 
 @CommandLine.Command(
@@ -235,12 +236,34 @@ public final class HeadlessMain implements Runnable {
         @CommandLine.Option(names = "--json", description = "Print machine-readable JSON.")
         boolean json;
 
+        @CommandLine.Option(names = "--dry-run", description = "Show selected entries without downloading them.")
+        boolean dryRun;
+
         @Override
         public Integer call() throws Exception {
             SubscriptionConfig config = SubscriptionService.readConfig(configPath);
             HistoryStore history = parent.history();
             DownloadService downloads = new DownloadService(history, parent.timeout());
             SubscriptionService subscriptions = new SubscriptionService(parent.client(), downloads, history);
+            if (dryRun) {
+                SyncPlan plan = subscriptions.plan(config);
+                if (json) {
+                    System.out.println(JsonSupport.writePretty(plan));
+                }
+                else {
+                    plan.selections().forEach(selection -> System.out.printf(
+                            "%-18s  %-28s  %-52s  %s%n",
+                            selection.status(),
+                            abbreviate(selection.subscription(), 28),
+                            abbreviate(selection.title(), 52),
+                            selection.id()));
+                    System.out.printf("subscriptions=%d matched=%d skipped=%d errors=%d%n",
+                            plan.subscriptions(), plan.matched(), plan.skipped(), plan.errors().size());
+                    plan.errors().forEach(error -> System.err.println("ERROR: " + error));
+                }
+                return plan.errors().isEmpty() ? 0 : 2;
+            }
+
             SyncResult result = subscriptions.sync(config);
             if (json) {
                 System.out.println(JsonSupport.writePretty(result));

--- a/headless/src/main/java/mediathek/headless/HistoryStore.java
+++ b/headless/src/main/java/mediathek/headless/HistoryStore.java
@@ -49,6 +49,20 @@ final class HistoryStore {
         }
     }
 
+    boolean isCompletedSource(String sourceUrl) throws SQLException {
+        if (sourceUrl == null || sourceUrl.isBlank()) {
+            return false;
+        }
+        String sql = "SELECT 1 FROM downloads WHERE source_url = ? AND status = 'completed'";
+        try (Connection connection = connect();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, sourceUrl);
+            try (ResultSet result = statement.executeQuery()) {
+                return result.next();
+            }
+        }
+    }
+
     void begin(Film film, Quality quality, Path outputPath, String sourceUrl) throws SQLException {
         String sql = """
                 INSERT INTO downloads (
@@ -150,6 +164,7 @@ final class HistoryStore {
                     )
                     """);
             statement.execute("CREATE INDEX IF NOT EXISTS downloads_status_idx ON downloads(status)");
+            statement.execute("CREATE INDEX IF NOT EXISTS downloads_source_url_idx ON downloads(source_url)");
         }
     }
 

--- a/headless/src/main/java/mediathek/headless/HistoryStore.java
+++ b/headless/src/main/java/mediathek/headless/HistoryStore.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 MediathekView contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package mediathek.headless;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static mediathek.headless.Model.DownloadRecord;
+import static mediathek.headless.Model.Film;
+import static mediathek.headless.Model.Quality;
+
+final class HistoryStore {
+    private final String jdbcUrl;
+
+    HistoryStore(Path databasePath) throws IOException, SQLException {
+        Path absolutePath = databasePath.toAbsolutePath().normalize();
+        Path parent = absolutePath.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        jdbcUrl = "jdbc:sqlite:" + absolutePath;
+        initialize();
+    }
+
+    boolean isCompleted(String id) throws SQLException {
+        String sql = "SELECT 1 FROM downloads WHERE id = ? AND status = 'completed'";
+        try (Connection connection = connect();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, id);
+            try (ResultSet result = statement.executeQuery()) {
+                return result.next();
+            }
+        }
+    }
+
+    void begin(Film film, Quality quality, Path outputPath, String sourceUrl) throws SQLException {
+        String sql = """
+                INSERT INTO downloads (
+                    id, status, channel, topic, title, quality, output_path, source_url,
+                    started_at, completed_at, error
+                ) VALUES (?, 'downloading', ?, ?, ?, ?, ?, ?, ?, NULL, NULL)
+                ON CONFLICT(id) DO UPDATE SET
+                    status = 'downloading', channel = excluded.channel, topic = excluded.topic,
+                    title = excluded.title, quality = excluded.quality,
+                    output_path = excluded.output_path, source_url = excluded.source_url,
+                    started_at = excluded.started_at, completed_at = NULL, error = NULL
+                """;
+        try (Connection connection = connect();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, film.id());
+            statement.setString(2, film.channel());
+            statement.setString(3, film.topic());
+            statement.setString(4, film.title());
+            statement.setString(5, quality.name().toLowerCase());
+            statement.setString(6, outputPath.toString());
+            statement.setString(7, sourceUrl);
+            statement.setString(8, Instant.now().toString());
+            statement.executeUpdate();
+        }
+    }
+
+    void complete(String id, Path outputPath) throws SQLException {
+        String sql = "UPDATE downloads SET status = 'completed', output_path = ?, completed_at = ?, error = NULL WHERE id = ?";
+        try (Connection connection = connect();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, outputPath.toString());
+            statement.setString(2, Instant.now().toString());
+            statement.setString(3, id);
+            statement.executeUpdate();
+        }
+    }
+
+    void fail(String id, Throwable error) throws SQLException {
+        String sql = "UPDATE downloads SET status = 'failed', error = ? WHERE id = ?";
+        try (Connection connection = connect();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, compactError(error));
+            statement.setString(2, id);
+            statement.executeUpdate();
+        }
+    }
+
+    List<DownloadRecord> list(int limit) throws SQLException {
+        int safeLimit = Math.max(1, Math.min(limit, 1000));
+        String sql = """
+                SELECT id, status, channel, topic, title, quality, output_path, source_url,
+                       started_at, completed_at, error
+                FROM downloads
+                ORDER BY started_at DESC
+                LIMIT ?
+                """;
+        List<DownloadRecord> records = new ArrayList<>();
+        try (Connection connection = connect();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setInt(1, safeLimit);
+            try (ResultSet result = statement.executeQuery()) {
+                while (result.next()) {
+                    records.add(new DownloadRecord(
+                            result.getString("id"),
+                            result.getString("status"),
+                            result.getString("channel"),
+                            result.getString("topic"),
+                            result.getString("title"),
+                            result.getString("quality"),
+                            result.getString("output_path"),
+                            result.getString("source_url"),
+                            result.getString("started_at"),
+                            result.getString("completed_at"),
+                            result.getString("error")));
+                }
+            }
+        }
+        return records;
+    }
+
+    private void initialize() throws SQLException {
+        try (Connection connection = connect();
+             Statement statement = connection.createStatement()) {
+            statement.execute("PRAGMA journal_mode = WAL");
+            statement.execute("PRAGMA busy_timeout = 10000");
+            statement.execute("""
+                    CREATE TABLE IF NOT EXISTS downloads (
+                        id TEXT PRIMARY KEY,
+                        status TEXT NOT NULL,
+                        channel TEXT,
+                        topic TEXT,
+                        title TEXT,
+                        quality TEXT,
+                        output_path TEXT,
+                        source_url TEXT,
+                        started_at TEXT NOT NULL,
+                        completed_at TEXT,
+                        error TEXT
+                    )
+                    """);
+            statement.execute("CREATE INDEX IF NOT EXISTS downloads_status_idx ON downloads(status)");
+        }
+    }
+
+    private Connection connect() throws SQLException {
+        Connection connection = DriverManager.getConnection(jdbcUrl);
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("PRAGMA busy_timeout = 10000");
+        }
+        return connection;
+    }
+
+    private static String compactError(Throwable error) {
+        String message = error.getMessage();
+        if (message == null || message.isBlank()) {
+            message = error.getClass().getSimpleName();
+        }
+        return message.length() > 2000 ? message.substring(0, 2000) : message;
+    }
+}

--- a/headless/src/main/java/mediathek/headless/JsonSupport.java
+++ b/headless/src/main/java/mediathek/headless/JsonSupport.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 MediathekView contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package mediathek.headless;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+final class JsonSupport {
+    static final ObjectMapper MAPPER = new ObjectMapper()
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    private JsonSupport() {
+    }
+
+    static String write(Object value) {
+        try {
+            return MAPPER.writeValueAsString(value);
+        }
+        catch (JsonProcessingException exception) {
+            throw new IllegalStateException("Could not serialize JSON", exception);
+        }
+    }
+
+    static String writePretty(Object value) {
+        try {
+            return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(value);
+        }
+        catch (JsonProcessingException exception) {
+            throw new IllegalStateException("Could not serialize JSON", exception);
+        }
+    }
+
+    static <T> T read(Path path, Class<T> type) throws IOException {
+        try (InputStream input = Files.newInputStream(path)) {
+            return MAPPER.readValue(input, type);
+        }
+    }
+}

--- a/headless/src/main/java/mediathek/headless/LibraryIndex.java
+++ b/headless/src/main/java/mediathek/headless/LibraryIndex.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 MediathekView contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package mediathek.headless;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.Normalizer;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static mediathek.headless.Model.Film;
+
+final class LibraryIndex {
+    private static final Set<String> VIDEO_EXTENSIONS = Set.of(
+            ".avi", ".m4v", ".mkv", ".mov", ".mp4", ".ts", ".webm");
+    private static final Pattern LEGACY_ID = Pattern.compile("-\\d{10}$");
+    private static final Pattern SHORT_ID = Pattern.compile("\\s+\\[[0-9a-fA-F]{8}]$");
+    private static final Pattern DATE_PREFIX = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}\\s+-\\s+");
+    private static final Pattern CONTENT_PREFIX = Pattern.compile(
+            "^(?:Sachgeschichte|Lachgeschichte|MausSpezial)\\s*[_:·-]\\s*",
+            Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+    private static final Pattern SPECIAL_PREFIX = Pattern.compile(
+            "^Spezial\\s*[-_:]\\s*", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+    private static final Pattern NON_ALPHANUMERIC = Pattern.compile("[^\\p{L}\\p{N}]+");
+
+    private final Path root;
+    private final Map<String, Path> videosByTitle = new HashMap<>();
+
+    private LibraryIndex(Path root) {
+        this.root = root.toAbsolutePath().normalize();
+    }
+
+    static LibraryIndex scan(Path root) throws IOException {
+        LibraryIndex index = new LibraryIndex(root);
+        try (Stream<Path> paths = Files.walk(index.root)) {
+            paths.filter(Files::isRegularFile).forEach(index::add);
+        }
+        return index;
+    }
+
+    Optional<Path> find(Film film) {
+        return Optional.ofNullable(videosByTitle.get(normalize(film.title())));
+    }
+
+    void add(Path path) {
+        Path absolute = path.toAbsolutePath().normalize();
+        if (!absolute.startsWith(root) || !isCompletedVideo(absolute)) {
+            return;
+        }
+
+        String stem = withoutExtension(absolute.getFileName().toString());
+        stem = SHORT_ID.matcher(stem).replaceFirst("");
+        stem = LEGACY_ID.matcher(stem).replaceFirst("");
+        stem = DATE_PREFIX.matcher(stem).replaceFirst("");
+        addTitle(stem, absolute);
+        addTitle(stripContentPrefix(stem), absolute);
+
+        Path relative = root.relativize(absolute);
+        if (relative.getNameCount() > 1) {
+            String directory = relative.getName(0).toString();
+            String prefix = directory + "-";
+            if (stem.regionMatches(true, 0, prefix, 0, prefix.length())) {
+                String title = stem.substring(prefix.length());
+                addTitle(title, absolute);
+                addTitle(stripContentPrefix(title), absolute);
+            }
+        }
+    }
+
+    private void addTitle(String title, Path path) {
+        String key = normalize(title);
+        if (!key.isBlank()) {
+            videosByTitle.putIfAbsent(key, path);
+        }
+    }
+
+    private static String stripContentPrefix(String value) {
+        String stripped = CONTENT_PREFIX.matcher(value).replaceFirst("");
+        return SPECIAL_PREFIX.matcher(stripped).replaceFirst("");
+    }
+
+    private static boolean isCompletedVideo(Path path) {
+        String name = path.getFileName().toString().toLowerCase(Locale.ROOT);
+        if (name.contains(".part.") || name.endsWith(".part")) {
+            return false;
+        }
+        return VIDEO_EXTENSIONS.stream().anyMatch(name::endsWith);
+    }
+
+    private static String withoutExtension(String filename) {
+        int dot = filename.lastIndexOf('.');
+        return dot > 0 ? filename.substring(0, dot) : filename;
+    }
+
+    static String normalize(String value) {
+        String normalized = Normalizer.normalize(value == null ? "" : value, Normalizer.Form.NFKC)
+                .toLowerCase(Locale.ROOT);
+        return NON_ALPHANUMERIC.matcher(normalized).replaceAll(" ").trim();
+    }
+}

--- a/headless/src/main/java/mediathek/headless/LibraryIndex.java
+++ b/headless/src/main/java/mediathek/headless/LibraryIndex.java
@@ -25,8 +25,10 @@ import static mediathek.headless.Model.Film;
 final class LibraryIndex {
     private static final Set<String> VIDEO_EXTENSIONS = Set.of(
             ".avi", ".m4v", ".mkv", ".mov", ".mp4", ".ts", ".webm");
-    private static final Pattern LEGACY_ID = Pattern.compile("-\\d{10}$");
+    private static final Pattern LEGACY_ID = Pattern.compile("-(-?\\d{10})$");
     private static final Pattern SHORT_ID = Pattern.compile("\\s+\\[[0-9a-fA-F]{8}]$");
+    private static final Pattern SOURCE_FINGERPRINT = Pattern.compile(
+            "\\s+\\[src-([0-9a-fA-F]{32})]$");
     private static final Pattern DATE_PREFIX = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}\\s+-\\s+");
     private static final Pattern CONTENT_PREFIX = Pattern.compile(
             "^(?:Sachgeschichte|Lachgeschichte|MausSpezial)\\s*[_:·-]\\s*",
@@ -36,7 +38,7 @@ final class LibraryIndex {
     private static final Pattern NON_ALPHANUMERIC = Pattern.compile("[^\\p{L}\\p{N}]+");
 
     private final Path root;
-    private final Map<String, Path> videosByTitle = new HashMap<>();
+    private final Map<EpisodeKey, Path> videosByEpisode = new HashMap<>();
 
     private LibraryIndex(Path root) {
         this.root = root.toAbsolutePath().normalize();
@@ -51,7 +53,23 @@ final class LibraryIndex {
     }
 
     Optional<Path> find(Film film) {
-        return Optional.ofNullable(videosByTitle.get(normalize(film.title())));
+        String title = normalize(film.title());
+        for (String sourceUrl : new String[]{film.videoUrl(), film.lowQualityUrl(), film.highQualityUrl()}) {
+            if (sourceUrl == null || sourceUrl.isBlank()) {
+                continue;
+            }
+            Path sourceMatch = videosByEpisode.get(new EpisodeKey(
+                    title, "source:" + EpisodeIdentity.sourceFingerprint(sourceUrl)));
+            if (sourceMatch != null) {
+                return Optional.of(sourceMatch);
+            }
+            Path legacyMatch = videosByEpisode.get(new EpisodeKey(
+                    title, "legacy:" + EpisodeIdentity.legacySourceHash(sourceUrl)));
+            if (legacyMatch != null) {
+                return Optional.of(legacyMatch);
+            }
+        }
+        return Optional.empty();
     }
 
     void add(Path path) {
@@ -62,27 +80,43 @@ final class LibraryIndex {
 
         String stem = withoutExtension(absolute.getFileName().toString());
         stem = SHORT_ID.matcher(stem).replaceFirst("");
-        stem = LEGACY_ID.matcher(stem).replaceFirst("");
+
+        String identity;
+        var sourceMatcher = SOURCE_FINGERPRINT.matcher(stem);
+        if (sourceMatcher.find()) {
+            identity = "source:" + sourceMatcher.group(1).toLowerCase(Locale.ROOT);
+            stem = sourceMatcher.replaceFirst("");
+        }
+        else {
+            var legacyMatcher = LEGACY_ID.matcher(stem);
+            if (!legacyMatcher.find()) {
+                return;
+            }
+            identity = "legacy:" + legacyMatcher.group(1);
+            stem = legacyMatcher.replaceFirst("");
+        }
+
         stem = DATE_PREFIX.matcher(stem).replaceFirst("");
-        addTitle(stem, absolute);
-        addTitle(stripContentPrefix(stem), absolute);
+        addTitle(stem, identity, absolute);
+        addTitle(stripContentPrefix(stem), identity, absolute);
 
         Path relative = root.relativize(absolute);
-        if (relative.getNameCount() > 1) {
-            String directory = relative.getName(0).toString();
+        Path parent = relative.getParent();
+        if (parent != null) {
+            String directory = parent.getFileName().toString();
             String prefix = directory + "-";
             if (stem.regionMatches(true, 0, prefix, 0, prefix.length())) {
                 String title = stem.substring(prefix.length());
-                addTitle(title, absolute);
-                addTitle(stripContentPrefix(title), absolute);
+                addTitle(title, identity, absolute);
+                addTitle(stripContentPrefix(title), identity, absolute);
             }
         }
     }
 
-    private void addTitle(String title, Path path) {
-        String key = normalize(title);
-        if (!key.isBlank()) {
-            videosByTitle.putIfAbsent(key, path);
+    private void addTitle(String title, String identity, Path path) {
+        String normalizedTitle = normalize(title);
+        if (!normalizedTitle.isBlank()) {
+            videosByEpisode.putIfAbsent(new EpisodeKey(normalizedTitle, identity), path);
         }
     }
 
@@ -108,5 +142,8 @@ final class LibraryIndex {
         String normalized = Normalizer.normalize(value == null ? "" : value, Normalizer.Form.NFKC)
                 .toLowerCase(Locale.ROOT);
         return NON_ALPHANUMERIC.matcher(normalized).replaceAll(" ").trim();
+    }
+
+    private record EpisodeKey(String title, String identity) {
     }
 }

--- a/headless/src/main/java/mediathek/headless/MediathekViewWebClient.java
+++ b/headless/src/main/java/mediathek/headless/MediathekViewWebClient.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 MediathekView contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package mediathek.headless;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+
+import static mediathek.headless.Model.ApiEnvelope;
+import static mediathek.headless.Model.Film;
+import static mediathek.headless.Model.SearchRequest;
+import static mediathek.headless.Model.SearchResult;
+
+final class MediathekViewWebClient {
+    static final URI DEFAULT_BASE_URI = URI.create("https://mediathekviewweb.de");
+
+    private final URI baseUri;
+    private final HttpClient httpClient;
+    private final Duration timeout;
+
+    MediathekViewWebClient(URI baseUri, Duration timeout) {
+        this(baseUri, timeout, HttpClient.newBuilder()
+                .connectTimeout(timeout)
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .build());
+    }
+
+    MediathekViewWebClient(URI baseUri, Duration timeout, HttpClient httpClient) {
+        String normalized = baseUri.toString().replaceFirst("/+$", "");
+        this.baseUri = URI.create(normalized);
+        this.timeout = timeout;
+        this.httpClient = httpClient;
+    }
+
+    SearchResult search(SearchRequest request) throws IOException, InterruptedException {
+        HttpRequest httpRequest = jsonPost("/api/query", JsonSupport.write(request.normalized()));
+        ApiEnvelope<SearchResult> response = send(httpRequest, new TypeReference<>() {
+        });
+        return requireResult(response);
+    }
+
+    List<Film> entries(List<String> ids) throws IOException, InterruptedException {
+        if (ids == null || ids.isEmpty()) {
+            return List.of();
+        }
+        HttpRequest httpRequest = jsonPost("/api/entries", JsonSupport.write(ids));
+        ApiEnvelope<SearchResult> response = send(httpRequest, new TypeReference<>() {
+        });
+        return requireResult(response).results();
+    }
+
+    Film entry(String id) throws IOException, InterruptedException {
+        List<Film> films = entries(List.of(id));
+        if (films.isEmpty()) {
+            throw new IOException("No MediathekView entry found for id " + id);
+        }
+        return films.get(0);
+    }
+
+    private HttpRequest jsonPost(String path, String json) {
+        return HttpRequest.newBuilder(baseUri.resolve(path))
+                .timeout(timeout)
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json")
+                .header("User-Agent", "MediathekView-Headless/0.1")
+                .POST(HttpRequest.BodyPublishers.ofString(json))
+                .build();
+    }
+
+    private <T> T send(HttpRequest request, TypeReference<T> type) throws IOException, InterruptedException {
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new IOException("MediathekViewWeb returned HTTP " + response.statusCode() + ": " + response.body());
+        }
+        return JsonSupport.MAPPER.readValue(response.body(), type);
+    }
+
+    private static <T> T requireResult(ApiEnvelope<T> envelope) throws IOException {
+        if (envelope == null) {
+            throw new IOException("MediathekViewWeb returned an empty response");
+        }
+        if (envelope.err() != null && !envelope.err().isEmpty()) {
+            throw new IOException("MediathekViewWeb error: " + String.join("; ", envelope.err()));
+        }
+        if (envelope.result() == null) {
+            throw new IOException("MediathekViewWeb response did not contain a result");
+        }
+        return envelope.result();
+    }
+}

--- a/headless/src/main/java/mediathek/headless/MediathekViewWebClient.java
+++ b/headless/src/main/java/mediathek/headless/MediathekViewWebClient.java
@@ -55,10 +55,29 @@ final class MediathekViewWebClient {
         if (ids == null || ids.isEmpty()) {
             return List.of();
         }
+        List<Film> films = requestEntries(ids);
+        if (films.size() == ids.size()) {
+            for (int index = 0; index < films.size(); index++) {
+                films.set(index, films.get(index).withId(ids.get(index)));
+            }
+            return List.copyOf(films);
+        }
+
+        films.clear();
+        for (String id : ids) {
+            List<Film> match = requestEntries(List.of(id));
+            if (!match.isEmpty()) {
+                films.add(match.get(0).withId(id));
+            }
+        }
+        return List.copyOf(films);
+    }
+
+    private List<Film> requestEntries(List<String> ids) throws IOException, InterruptedException {
         HttpRequest httpRequest = jsonPost("/api/entries", JsonSupport.write(ids));
         ApiEnvelope<SearchResult> response = send(httpRequest, new TypeReference<>() {
         });
-        return requireResult(response).results();
+        return new java.util.ArrayList<>(requireResult(response).results());
     }
 
     Film entry(String id) throws IOException, InterruptedException {

--- a/headless/src/main/java/mediathek/headless/Model.java
+++ b/headless/src/main/java/mediathek/headless/Model.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026 MediathekView contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package mediathek.headless;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Locale;
+
+final class Model {
+    private Model() {
+    }
+
+    record QueryClause(List<String> fields, String query) {
+        QueryClause {
+            fields = fields == null ? List.of() : List.copyOf(fields);
+            query = query == null ? "" : query.trim();
+        }
+    }
+
+    record SearchRequest(
+            List<QueryClause> queries,
+            String sortBy,
+            String sortOrder,
+            Boolean future,
+            Integer offset,
+            Integer size,
+            @JsonProperty("duration_min") Integer durationMin,
+            @JsonProperty("duration_max") Integer durationMax) {
+
+        SearchRequest normalized() {
+            int normalizedSize = size == null ? 15 : Math.max(1, Math.min(size, 1000));
+            int normalizedOffset = offset == null ? 0 : Math.max(0, offset);
+            return new SearchRequest(
+                    queries == null ? List.of() : List.copyOf(queries),
+                    sortBy == null ? "timestamp" : sortBy,
+                    sortOrder == null ? "desc" : sortOrder,
+                    future != null && future,
+                    normalizedOffset,
+                    normalizedSize,
+                    durationMin,
+                    durationMax);
+        }
+    }
+
+    record Film(
+            String id,
+            String channel,
+            String topic,
+            String title,
+            String description,
+            long timestamp,
+            int duration,
+            long size,
+            @JsonProperty("url_website") String websiteUrl,
+            @JsonProperty("url_subtitle") String subtitleUrl,
+            @JsonProperty("url_video") String videoUrl,
+            @JsonProperty("url_video_low") String lowQualityUrl,
+            @JsonProperty("url_video_hd") String highQualityUrl) {
+    }
+
+    record QueryInfo(
+            long filmlisteTimestamp,
+            String searchEngineTime,
+            int resultCount,
+            long totalResults,
+            String totalRelation,
+            long totalEntries) {
+    }
+
+    record SearchResult(List<Film> results, QueryInfo queryInfo) {
+        SearchResult {
+            results = results == null ? List.of() : List.copyOf(results);
+        }
+    }
+
+    record ApiEnvelope<T>(T result, List<String> err) {
+    }
+
+    enum Quality {
+        HD,
+        SD,
+        LOW;
+
+        static Quality parse(String value) {
+            if (value == null || value.isBlank()) {
+                return HD;
+            }
+            return switch (value.trim().toLowerCase(Locale.ROOT)) {
+                case "hd", "high" -> HD;
+                case "sd", "normal" -> SD;
+                case "low", "lq", "small" -> LOW;
+                default -> throw new IllegalArgumentException("Unknown quality: " + value);
+            };
+        }
+
+        String selectUrl(Film film) {
+            return switch (this) {
+                case HD -> firstNonBlank(film.highQualityUrl(), film.videoUrl(), film.lowQualityUrl());
+                case SD -> firstNonBlank(film.videoUrl(), film.highQualityUrl(), film.lowQualityUrl());
+                case LOW -> firstNonBlank(film.lowQualityUrl(), film.videoUrl(), film.highQualityUrl());
+            };
+        }
+
+        private static String firstNonBlank(String... values) {
+            for (String value : values) {
+                if (value != null && !value.isBlank()) {
+                    return value;
+                }
+            }
+            return "";
+        }
+    }
+
+    record SubscriptionConfig(String outputDirectory, List<Subscription> subscriptions) {
+        SubscriptionConfig {
+            subscriptions = subscriptions == null ? List.of() : List.copyOf(subscriptions);
+        }
+    }
+
+    record Subscription(
+            String name,
+            List<QueryClause> queries,
+            String subdirectory,
+            String quality,
+            Integer maxResults,
+            Integer minDuration,
+            Integer maxDuration,
+            Boolean includeFuture,
+            Boolean subtitles) {
+
+        Subscription {
+            queries = queries == null ? List.of() : List.copyOf(queries);
+        }
+
+        Quality parsedQuality() {
+            return Quality.parse(quality);
+        }
+
+        int resultLimit() {
+            return maxResults == null ? 10 : Math.max(1, Math.min(maxResults, 1000));
+        }
+
+        boolean wantsSubtitles() {
+            return subtitles == null || subtitles;
+        }
+    }
+
+    record DownloadRecord(
+            String id,
+            String status,
+            String channel,
+            String topic,
+            String title,
+            String quality,
+            String outputPath,
+            String sourceUrl,
+            String startedAt,
+            String completedAt,
+            String error) {
+    }
+
+    record SyncResult(int subscriptions, int matched, int downloaded, int skipped, List<String> errors) {
+    }
+
+    record ApiDownloadRequest(String id, String subdirectory, String quality, Boolean subtitles) {
+    }
+}

--- a/headless/src/main/java/mediathek/headless/Model.java
+++ b/headless/src/main/java/mediathek/headless/Model.java
@@ -63,6 +63,23 @@ final class Model {
             @JsonProperty("url_video") String videoUrl,
             @JsonProperty("url_video_low") String lowQualityUrl,
             @JsonProperty("url_video_hd") String highQualityUrl) {
+
+        Film withId(String requestedId) {
+            return new Film(
+                    requestedId,
+                    channel,
+                    topic,
+                    title,
+                    description,
+                    timestamp,
+                    duration,
+                    size,
+                    websiteUrl,
+                    subtitleUrl,
+                    videoUrl,
+                    lowQualityUrl,
+                    highQualityUrl);
+        }
     }
 
     record QueryInfo(

--- a/headless/src/main/java/mediathek/headless/Model.java
+++ b/headless/src/main/java/mediathek/headless/Model.java
@@ -133,7 +133,11 @@ final class Model {
             Integer minDuration,
             Integer maxDuration,
             Boolean includeFuture,
-            Boolean subtitles) {
+            Boolean subtitles,
+            String includeTitleRegex,
+            String excludeTitleRegex,
+            String includeTopicRegex,
+            String excludeTopicRegex) {
 
         Subscription {
             queries = queries == null ? List.of() : List.copyOf(queries);
@@ -167,6 +171,28 @@ final class Model {
     }
 
     record SyncResult(int subscriptions, int matched, int downloaded, int skipped, List<String> errors) {
+        SyncResult {
+            errors = errors == null ? List.of() : List.copyOf(errors);
+        }
+    }
+
+    record SyncSelection(
+            String subscription,
+            String status,
+            String id,
+            String channel,
+            String topic,
+            String title,
+            long timestamp,
+            int duration) {
+    }
+
+    record SyncPlan(int subscriptions, int matched, int skipped,
+                    List<SyncSelection> selections, List<String> errors) {
+        SyncPlan {
+            selections = selections == null ? List.of() : List.copyOf(selections);
+            errors = errors == null ? List.of() : List.copyOf(errors);
+        }
     }
 
     record ApiDownloadRequest(String id, String subdirectory, String quality, Boolean subtitles) {

--- a/headless/src/main/java/mediathek/headless/SubscriptionService.java
+++ b/headless/src/main/java/mediathek/headless/SubscriptionService.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 MediathekView contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package mediathek.headless;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static mediathek.headless.Model.Film;
+import static mediathek.headless.Model.SearchRequest;
+import static mediathek.headless.Model.SearchResult;
+import static mediathek.headless.Model.Subscription;
+import static mediathek.headless.Model.SubscriptionConfig;
+import static mediathek.headless.Model.SyncResult;
+
+final class SubscriptionService {
+    private final MediathekViewWebClient client;
+    private final DownloadService downloads;
+    private final HistoryStore history;
+
+    SubscriptionService(MediathekViewWebClient client, DownloadService downloads, HistoryStore history) {
+        this.client = client;
+        this.downloads = downloads;
+        this.history = history;
+    }
+
+    SyncResult sync(SubscriptionConfig config) throws Exception {
+        if (config.outputDirectory() == null || config.outputDirectory().isBlank()) {
+            throw new IllegalArgumentException("Subscription config requires outputDirectory");
+        }
+        Path outputRoot = Path.of(config.outputDirectory()).toAbsolutePath().normalize();
+        int matched = 0;
+        int downloaded = 0;
+        int skipped = 0;
+        List<String> errors = new ArrayList<>();
+
+        for (Subscription subscription : config.subscriptions()) {
+            if (subscription.name() == null || subscription.name().isBlank()) {
+                errors.add("Subscription without a name was skipped");
+                continue;
+            }
+            if (subscription.queries().isEmpty()) {
+                errors.add(subscription.name() + ": no queries configured");
+                continue;
+            }
+
+            SearchRequest request = new SearchRequest(
+                    subscription.queries(),
+                    "timestamp",
+                    "desc",
+                    subscription.includeFuture() != null && subscription.includeFuture(),
+                    0,
+                    subscription.resultLimit(),
+                    subscription.minDuration(),
+                    subscription.maxDuration());
+
+            SearchResult result;
+            try {
+                result = client.search(request);
+            }
+            catch (Exception exception) {
+                errors.add(subscription.name() + ": search failed: " + compactError(exception));
+                continue;
+            }
+            matched += result.results().size();
+            List<Film> films = new ArrayList<>(result.results());
+            Collections.reverse(films);
+
+            for (Film film : films) {
+                try {
+                    if (history.isCompleted(film.id())) {
+                        skipped++;
+                        continue;
+                    }
+                    Path path = downloads.download(
+                            film,
+                            outputRoot,
+                            subscription.subdirectory(),
+                            subscription.parsedQuality(),
+                            subscription.wantsSubtitles(),
+                            false);
+                    if (path == null) {
+                        skipped++;
+                    }
+                    else {
+                        downloaded++;
+                    }
+                }
+                catch (Exception exception) {
+                    errors.add(subscription.name() + " / " + film.title() + ": " + compactError(exception));
+                }
+            }
+        }
+
+        return new SyncResult(config.subscriptions().size(), matched, downloaded, skipped, List.copyOf(errors));
+    }
+
+    static SubscriptionConfig readConfig(Path path) throws Exception {
+        return JsonSupport.read(path.toAbsolutePath().normalize(), SubscriptionConfig.class);
+    }
+
+    private static String compactError(Throwable error) {
+        String message = error.getMessage();
+        if (message == null || message.isBlank()) {
+            return error.getClass().getSimpleName();
+        }
+        return message.length() > 500 ? message.substring(0, 500) : message;
+    }
+}

--- a/headless/src/main/java/mediathek/headless/SubscriptionService.java
+++ b/headless/src/main/java/mediathek/headless/SubscriptionService.java
@@ -11,14 +11,20 @@ package mediathek.headless;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import static mediathek.headless.Model.Film;
 import static mediathek.headless.Model.SearchRequest;
 import static mediathek.headless.Model.SearchResult;
 import static mediathek.headless.Model.Subscription;
 import static mediathek.headless.Model.SubscriptionConfig;
+import static mediathek.headless.Model.SyncPlan;
 import static mediathek.headless.Model.SyncResult;
+import static mediathek.headless.Model.SyncSelection;
 
 final class SubscriptionService {
     private final MediathekViewWebClient client;
@@ -32,13 +38,54 @@ final class SubscriptionService {
     }
 
     SyncResult sync(SubscriptionConfig config) throws Exception {
-        if (config.outputDirectory() == null || config.outputDirectory().isBlank()) {
-            throw new IllegalArgumentException("Subscription config requires outputDirectory");
+        SyncPlan plan = plan(config);
+        if (!plan.errors().isEmpty()) {
+            return new SyncResult(plan.subscriptions(), plan.matched(), 0, plan.skipped(), plan.errors());
         }
-        Path outputRoot = Path.of(config.outputDirectory()).toAbsolutePath().normalize();
-        int matched = 0;
+
+        Path outputRoot = outputRoot(config);
         int downloaded = 0;
+        int skipped = plan.skipped();
+        List<String> errors = new ArrayList<>();
+
+        for (SyncSelection selection : plan.selections()) {
+            if (selection.status().equals("already-downloaded")) {
+                continue;
+            }
+            Subscription subscription = config.subscriptions().stream()
+                    .filter(candidate -> candidate.name().equals(selection.subscription()))
+                    .findFirst()
+                    .orElseThrow();
+            try {
+                Film film = client.entry(selection.id());
+                Path path = downloads.download(
+                        film,
+                        outputRoot,
+                        subscription.subdirectory(),
+                        subscription.parsedQuality(),
+                        subscription.wantsSubtitles(),
+                        false);
+                if (path == null) {
+                    skipped++;
+                }
+                else {
+                    downloaded++;
+                }
+            }
+            catch (Exception exception) {
+                errors.add(subscription.name() + " / " + selection.title() + ": " + compactError(exception));
+            }
+        }
+
+        return new SyncResult(plan.subscriptions(), plan.matched(), downloaded, skipped, List.copyOf(errors));
+    }
+
+    SyncPlan plan(SubscriptionConfig config) throws Exception {
+        outputRoot(config);
+
+        int matched = 0;
         int skipped = 0;
+        List<SyncSelection> selections = new ArrayList<>();
         List<String> errors = new ArrayList<>();
 
         for (Subscription subscription : config.subscriptions()) {
@@ -51,55 +98,95 @@ final class SubscriptionService {
                 continue;
             }
 
-            SearchRequest request = new SearchRequest(
-                    subscription.queries(),
-                    "timestamp",
-                    "desc",
-                    subscription.includeFuture() != null && subscription.includeFuture(),
-                    0,
-                    subscription.resultLimit(),
-                    subscription.minDuration(),
-                    subscription.maxDuration());
-
-            SearchResult result;
+            List<Film> films;
             try {
-                result = client.search(request);
+                films = findMatches(subscription);
             }
             catch (Exception exception) {
                 errors.add(subscription.name() + ": search failed: " + compactError(exception));
                 continue;
             }
-            matched += result.results().size();
-            List<Film> films = new ArrayList<>(result.results());
+            matched += films.size();
             Collections.reverse(films);
 
             for (Film film : films) {
-                try {
-                    if (history.isCompleted(film.id())) {
-                        skipped++;
-                        continue;
-                    }
-                    Path path = downloads.download(
-                            film,
-                            outputRoot,
-                            subscription.subdirectory(),
-                            subscription.parsedQuality(),
-                            subscription.wantsSubtitles(),
-                            false);
-                    if (path == null) {
-                        skipped++;
-                    }
-                    else {
-                        downloaded++;
-                    }
+                String sourceUrl = subscription.parsedQuality().selectUrl(film);
+                boolean completed = history.isCompleted(film.id()) || history.isCompletedSource(sourceUrl);
+                if (completed) {
+                    skipped++;
                 }
-                catch (Exception exception) {
-                    errors.add(subscription.name() + " / " + film.title() + ": " + compactError(exception));
-                }
+                selections.add(new SyncSelection(
+                        subscription.name(),
+                        completed ? "already-downloaded" : "would-download",
+                        film.id(),
+                        film.channel(),
+                        film.topic(),
+                        film.title(),
+                        film.timestamp(),
+                        film.duration()));
             }
         }
 
-        return new SyncResult(config.subscriptions().size(), matched, downloaded, skipped, List.copyOf(errors));
+        return new SyncPlan(
+                config.subscriptions().size(), matched, skipped,
+                List.copyOf(selections), List.copyOf(errors));
+    }
+
+    private List<Film> findMatches(Subscription subscription) throws Exception {
+        FilmFilter filter = FilmFilter.compile(subscription);
+        int resultLimit = subscription.resultLimit();
+        int pageSize = Math.min(1000, Math.max(50, resultLimit * 5));
+        int offset = 0;
+        List<Film> matches = new ArrayList<>();
+        Set<String> sources = new HashSet<>();
+
+        while (matches.size() < resultLimit) {
+            SearchRequest request = new SearchRequest(
+                    subscription.queries(),
+                    "timestamp",
+                    "desc",
+                    subscription.includeFuture() != null && subscription.includeFuture(),
+                    offset,
+                    pageSize,
+                    subscription.minDuration(),
+                    subscription.maxDuration());
+            SearchResult result = client.search(request);
+            for (Film film : result.results()) {
+                if (filter.matches(film) && sources.add(contentKey(subscription, film))) {
+                    matches.add(film);
+                    if (matches.size() == resultLimit) {
+                        break;
+                    }
+                }
+            }
+
+            int received = result.results().size();
+            if (received == 0) {
+                break;
+            }
+            offset += received;
+            if (received < pageSize
+                    || result.queryInfo() != null && offset >= result.queryInfo().totalResults()) {
+                break;
+            }
+        }
+        return matches;
+    }
+
+    private static String contentKey(Subscription subscription, Film film) {
+        String sourceUrl = subscription.parsedQuality().selectUrl(film);
+        if (sourceUrl != null && !sourceUrl.isBlank()) {
+            return "url:" + sourceUrl;
+        }
+        return "metadata:" + film.topic() + '\n' + film.title() + '\n'
+                + film.timestamp() + '\n' + film.duration();
+    }
+
+    private static Path outputRoot(SubscriptionConfig config) {
+        if (config.outputDirectory() == null || config.outputDirectory().isBlank()) {
+            throw new IllegalArgumentException("Subscription config requires outputDirectory");
+        }
+        return Path.of(config.outputDirectory()).toAbsolutePath().normalize();
     }
 
     static SubscriptionConfig readConfig(Path path) throws Exception {
@@ -112,5 +199,47 @@ final class SubscriptionService {
             return error.getClass().getSimpleName();
         }
         return message.length() > 500 ? message.substring(0, 500) : message;
+    }
+
+    private record FilmFilter(
+            Pattern includeTitle,
+            Pattern excludeTitle,
+            Pattern includeTopic,
+            Pattern excludeTopic) {
+
+        static FilmFilter compile(Subscription subscription) {
+            return new FilmFilter(
+                    compile("includeTitleRegex", subscription.includeTitleRegex()),
+                    compile("excludeTitleRegex", subscription.excludeTitleRegex()),
+                    compile("includeTopicRegex", subscription.includeTopicRegex()),
+                    compile("excludeTopicRegex", subscription.excludeTopicRegex()));
+        }
+
+        boolean matches(Film film) {
+            return included(includeTitle, film.title())
+                    && excluded(excludeTitle, film.title())
+                    && included(includeTopic, film.topic())
+                    && excluded(excludeTopic, film.topic());
+        }
+
+        private static boolean included(Pattern pattern, String value) {
+            return pattern == null || pattern.matcher(value == null ? "" : value).find();
+        }
+
+        private static boolean excluded(Pattern pattern, String value) {
+            return pattern == null || !pattern.matcher(value == null ? "" : value).find();
+        }
+
+        private static Pattern compile(String field, String value) {
+            if (value == null || value.isBlank()) {
+                return null;
+            }
+            try {
+                return Pattern.compile(value, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+            }
+            catch (PatternSyntaxException exception) {
+                throw new IllegalArgumentException(field + " is invalid: " + exception.getDescription(), exception);
+            }
+        }
     }
 }

--- a/headless/src/main/java/mediathek/headless/SubscriptionService.java
+++ b/headless/src/main/java/mediathek/headless/SubscriptionService.java
@@ -88,6 +88,13 @@ final class SubscriptionService {
     }
 
     private SyncPlan plan(SubscriptionConfig config, LibraryIndex library) throws Exception {
+        List<String> duplicateNameErrors = duplicateNameErrors(config.subscriptions());
+        if (!duplicateNameErrors.isEmpty()) {
+            return new SyncPlan(
+                    config.subscriptions().size(), 0, 0,
+                    List.of(), duplicateNameErrors);
+        }
+
         int matched = 0;
         int skipped = 0;
         List<SyncSelection> selections = new ArrayList<>();
@@ -186,6 +193,19 @@ final class SubscriptionService {
         }
         return "metadata:" + film.topic() + '\n' + film.title() + '\n'
                 + film.timestamp() + '\n' + film.duration();
+    }
+
+    private static List<String> duplicateNameErrors(List<Subscription> subscriptions) {
+        Set<String> names = new HashSet<>();
+        Set<String> duplicates = new HashSet<>();
+        List<String> errors = new ArrayList<>();
+        for (Subscription subscription : subscriptions) {
+            String name = subscription.name();
+            if (name != null && !name.isBlank() && !names.add(name) && duplicates.add(name)) {
+                errors.add("Duplicate subscription name: " + name);
+            }
+        }
+        return List.copyOf(errors);
     }
 
     private static Path outputRoot(SubscriptionConfig config) {

--- a/headless/src/main/java/mediathek/headless/SubscriptionService.java
+++ b/headless/src/main/java/mediathek/headless/SubscriptionService.java
@@ -38,18 +38,19 @@ final class SubscriptionService {
     }
 
     SyncResult sync(SubscriptionConfig config) throws Exception {
-        SyncPlan plan = plan(config);
+        Path outputRoot = outputRoot(config);
+        LibraryIndex library = LibraryIndex.scan(outputRoot);
+        SyncPlan plan = plan(config, library);
         if (!plan.errors().isEmpty()) {
             return new SyncResult(plan.subscriptions(), plan.matched(), 0, plan.skipped(), plan.errors());
         }
 
-        Path outputRoot = outputRoot(config);
         int downloaded = 0;
         int skipped = plan.skipped();
         List<String> errors = new ArrayList<>();
 
         for (SyncSelection selection : plan.selections()) {
-            if (selection.status().equals("already-downloaded")) {
+            if (!selection.status().equals("would-download")) {
                 continue;
             }
             Subscription subscription = config.subscriptions().stream()
@@ -64,7 +65,8 @@ final class SubscriptionService {
                         subscription.subdirectory(),
                         subscription.parsedQuality(),
                         subscription.wantsSubtitles(),
-                        false);
+                        false,
+                        library);
                 if (path == null) {
                     skipped++;
                 }
@@ -81,8 +83,11 @@ final class SubscriptionService {
     }
 
     SyncPlan plan(SubscriptionConfig config) throws Exception {
-        outputRoot(config);
+        Path outputRoot = outputRoot(config);
+        return plan(config, LibraryIndex.scan(outputRoot));
+    }
 
+    private SyncPlan plan(SubscriptionConfig config, LibraryIndex library) throws Exception {
         int matched = 0;
         int skipped = 0;
         List<SyncSelection> selections = new ArrayList<>();
@@ -111,13 +116,14 @@ final class SubscriptionService {
 
             for (Film film : films) {
                 String sourceUrl = subscription.parsedQuality().selectUrl(film);
-                boolean completed = history.isCompleted(film.id()) || history.isCompletedSource(sourceUrl);
-                if (completed) {
+                boolean downloaded = history.isCompleted(film.id()) || history.isCompletedSource(sourceUrl);
+                boolean inLibrary = !downloaded && library.find(film).isPresent();
+                if (downloaded || inLibrary) {
                     skipped++;
                 }
                 selections.add(new SyncSelection(
                         subscription.name(),
-                        completed ? "already-downloaded" : "would-download",
+                        downloaded ? "already-downloaded" : inLibrary ? "already-in-library" : "would-download",
                         film.id(),
                         film.channel(),
                         film.topic(),

--- a/headless/src/test/java/mediathek/headless/DownloadServiceTest.java
+++ b/headless/src/test/java/mediathek/headless/DownloadServiceTest.java
@@ -60,6 +60,7 @@ class DownloadServiceTest {
         assertTrue(downloaded.startsWith(tempDirectory.resolve("Maus")));
         assertArrayEquals(video, Files.readAllBytes(downloaded));
         assertTrue(history.isCompleted("stable-id"));
+        assertTrue(history.isCompletedSource(videoUrl));
         assertEquals("completed", history.list(10).get(0).status());
         assertNull(service.download(film, tempDirectory, "Maus", Quality.HD, false, false));
         try (var files = Files.walk(tempDirectory)) {

--- a/headless/src/test/java/mediathek/headless/DownloadServiceTest.java
+++ b/headless/src/test/java/mediathek/headless/DownloadServiceTest.java
@@ -13,17 +13,27 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static mediathek.headless.Model.Film;
 import static mediathek.headless.Model.Quality;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DownloadServiceTest {
@@ -58,6 +68,8 @@ class DownloadServiceTest {
         Path downloaded = service.download(film, tempDirectory, "Maus", Quality.HD, false, false);
 
         assertTrue(downloaded.startsWith(tempDirectory.resolve("Maus")));
+        assertTrue(downloaded.getFileName().toString().contains(
+                "[src-" + EpisodeIdentity.sourceFingerprint(videoUrl) + "]"));
         assertArrayEquals(video, Files.readAllBytes(downloaded));
         assertTrue(history.isCompleted("stable-id"));
         assertTrue(history.isCompletedSource(videoUrl));
@@ -76,17 +88,19 @@ class DownloadServiceTest {
 
     @Test
     void skipsAnEntryAlreadyPresentUnderALegacyFilename() throws Exception {
+        String sourceUrl = "https://example.test/unreachable.mp4";
         Path directory = Files.createDirectories(
                 tempDirectory.resolve("Anna, Nina, Pia und die wilden Tiere"));
         Path existing = Files.writeString(directory.resolve(
-                "Anna, Nina, Pia und die wilden Tiere-Die Raubkatzen von Brasilien-1011316568.mp4"),
+                "Anna, Nina, Pia und die wilden Tiere-Die Raubkatzen von Brasilien-"
+                        + EpisodeIdentity.legacySourceHash(sourceUrl) + ".mp4"),
                 "existing-video");
         HistoryStore history = new HistoryStore(tempDirectory.resolve("state/history.db"));
         DownloadService service = new DownloadService(history, Duration.ofSeconds(1));
         Film film = new Film(
                 "new-catalog-id", "BR", "Anna, Nina, Pia und die wilden Tiere",
                 "Die Raubkatzen von Brasilien", "", 1700000000, 1400, 1,
-                "", "", "https://example.test/unreachable.mp4", "", "");
+                "", "", sourceUrl, "", "");
 
         assertNull(service.download(film, tempDirectory, "Anna und die wilden Tiere",
                 Quality.HD, false, false));
@@ -94,10 +108,102 @@ class DownloadServiceTest {
         assertTrue(history.list(10).isEmpty());
     }
 
+    @Test
+    void timesOutAndTerminatesAStalledFfmpegProcess() throws Exception {
+        HistoryStore history = new HistoryStore(tempDirectory.resolve("state/history.db"));
+        AtomicReference<List<String>> command = new AtomicReference<>();
+        AtomicReference<BlockingProcess> launched = new AtomicReference<>();
+        DownloadService.ProcessLauncher launcher = builder -> {
+            command.set(List.copyOf(builder.command()));
+            BlockingProcess process = new BlockingProcess();
+            launched.set(process);
+            return process;
+        };
+        DownloadService service = new DownloadService(
+                history,
+                Duration.ofSeconds(5),
+                HttpClient.newHttpClient(),
+                Duration.ofMillis(10),
+                launcher);
+        Film film = film("stalled-id", "https://example.test/stalled.m3u8");
+
+        var exception = assertThrows(IOException.class, () -> service.download(
+                film, tempDirectory, "HLS", Quality.HD, false, false));
+
+        assertTrue(exception.getMessage().contains("ffmpeg timed out after"));
+        int timeoutOption = command.get().indexOf("-rw_timeout");
+        assertTrue(timeoutOption >= 0);
+        assertEquals("5000000", command.get().get(timeoutOption + 1));
+        assertFalse(launched.get().isAlive());
+        assertEquals("failed", history.list(10).get(0).status());
+        try (var files = Files.walk(tempDirectory)) {
+            assertTrue(files.noneMatch(path -> {
+                String name = path.getFileName().toString();
+                return name.contains(".part") || name.startsWith(".ffmpeg-");
+            }));
+        }
+    }
+
     private static Film film(String id, String videoUrl) {
         return new Film(
                 id, "WDR", "Die Maus", "Eine Folge: Test?", "Description",
                 1700000000, 1800, 100, "https://example.test", "",
                 videoUrl, "", "");
+    }
+
+    private static final class BlockingProcess extends Process {
+        private final CountDownLatch terminated = new CountDownLatch(1);
+        private volatile boolean alive = true;
+
+        @Override
+        public OutputStream getOutputStream() {
+            return OutputStream.nullOutputStream();
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return InputStream.nullInputStream();
+        }
+
+        @Override
+        public InputStream getErrorStream() {
+            return InputStream.nullInputStream();
+        }
+
+        @Override
+        public int waitFor() throws InterruptedException {
+            terminated.await();
+            return 143;
+        }
+
+        @Override
+        public boolean waitFor(long timeout, TimeUnit unit) throws InterruptedException {
+            return terminated.await(timeout, unit);
+        }
+
+        @Override
+        public int exitValue() {
+            if (alive) {
+                throw new IllegalThreadStateException("process is still running");
+            }
+            return 143;
+        }
+
+        @Override
+        public void destroy() {
+            alive = false;
+            terminated.countDown();
+        }
+
+        @Override
+        public Process destroyForcibly() {
+            destroy();
+            return this;
+        }
+
+        @Override
+        public boolean isAlive() {
+            return alive;
+        }
     }
 }

--- a/headless/src/test/java/mediathek/headless/DownloadServiceTest.java
+++ b/headless/src/test/java/mediathek/headless/DownloadServiceTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 MediathekView contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package mediathek.headless;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+
+import static mediathek.headless.Model.Film;
+import static mediathek.headless.Model.Quality;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DownloadServiceTest {
+    @TempDir
+    Path tempDirectory;
+
+    private HttpServer server;
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void downloadsAtomicallyAndDeduplicatesByEntryId() throws Exception {
+        byte[] video = "fake-video-content".getBytes(StandardCharsets.UTF_8);
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/video.mp4", exchange -> {
+            exchange.sendResponseHeaders(200, video.length);
+            exchange.getResponseBody().write(video);
+            exchange.close();
+        });
+        server.start();
+        String videoUrl = "http://127.0.0.1:" + server.getAddress().getPort() + "/video.mp4";
+
+        HistoryStore history = new HistoryStore(tempDirectory.resolve("state/history.db"));
+        DownloadService service = new DownloadService(history, Duration.ofSeconds(5));
+        Film film = film("stable-id", videoUrl);
+
+        Path downloaded = service.download(film, tempDirectory, "Maus", Quality.HD, false, false);
+
+        assertTrue(downloaded.startsWith(tempDirectory.resolve("Maus")));
+        assertArrayEquals(video, Files.readAllBytes(downloaded));
+        assertTrue(history.isCompleted("stable-id"));
+        assertEquals("completed", history.list(10).get(0).status());
+        assertNull(service.download(film, tempDirectory, "Maus", Quality.HD, false, false));
+        try (var files = Files.walk(tempDirectory)) {
+            assertTrue(files.noneMatch(path -> path.getFileName().toString().contains(".part")));
+        }
+    }
+
+    @Test
+    void sanitizesUnsafeFilenameCharacters() {
+        assertEquals("folder_name_", DownloadService.sanitizePathSegment(" folder/name? "));
+        assertEquals("download", DownloadService.sanitizePathSegment(".."));
+    }
+
+    private static Film film(String id, String videoUrl) {
+        return new Film(
+                id, "WDR", "Die Maus", "Eine Folge: Test?", "Description",
+                1700000000, 1800, 100, "https://example.test", "",
+                videoUrl, "", "");
+    }
+}

--- a/headless/src/test/java/mediathek/headless/DownloadServiceTest.java
+++ b/headless/src/test/java/mediathek/headless/DownloadServiceTest.java
@@ -87,6 +87,31 @@ class DownloadServiceTest {
     }
 
     @Test
+    void resolvesSchemeRelativeMediaUrlsAgainstHttps() throws Exception {
+        assertEquals("https://cdn-storage.br.de/abc/def.mp4",
+                DownloadService.normalizeMediaUrl("//cdn-storage.br.de/abc/def.mp4", "entry-id"));
+        assertEquals("https://example.test/video.mp4",
+                DownloadService.normalizeMediaUrl(" https://example.test/video.mp4 ", "entry-id"));
+        assertEquals("http://example.test/video.mp4",
+                DownloadService.normalizeMediaUrl("http://example.test/video.mp4", "entry-id"));
+    }
+
+    @Test
+    void rejectsMediaUrlsTheDownloaderCannotFetch() {
+        var unsupported = assertThrows(IOException.class,
+                () -> DownloadService.normalizeMediaUrl("ftp://example.test/video.mp4", "entry-id"));
+        assertTrue(unsupported.getMessage().contains("unsupported video URL scheme"));
+        assertTrue(unsupported.getMessage().contains("entry-id"));
+
+        var schemeless = assertThrows(IOException.class,
+                () -> DownloadService.normalizeMediaUrl("cdn-storage.br.de/abc/def.mp4", "entry-id"));
+        assertTrue(schemeless.getMessage().contains("unsupported video URL scheme"));
+
+        assertThrows(IOException.class,
+                () -> DownloadService.normalizeMediaUrl("https://exa mple.test/video.mp4", "entry-id"));
+    }
+
+    @Test
     void skipsAnEntryAlreadyPresentUnderALegacyFilename() throws Exception {
         String sourceUrl = "https://example.test/unreachable.mp4";
         Path directory = Files.createDirectories(

--- a/headless/src/test/java/mediathek/headless/DownloadServiceTest.java
+++ b/headless/src/test/java/mediathek/headless/DownloadServiceTest.java
@@ -74,6 +74,26 @@ class DownloadServiceTest {
         assertEquals("download", DownloadService.sanitizePathSegment(".."));
     }
 
+    @Test
+    void skipsAnEntryAlreadyPresentUnderALegacyFilename() throws Exception {
+        Path directory = Files.createDirectories(
+                tempDirectory.resolve("Anna, Nina, Pia und die wilden Tiere"));
+        Path existing = Files.writeString(directory.resolve(
+                "Anna, Nina, Pia und die wilden Tiere-Die Raubkatzen von Brasilien-1011316568.mp4"),
+                "existing-video");
+        HistoryStore history = new HistoryStore(tempDirectory.resolve("state/history.db"));
+        DownloadService service = new DownloadService(history, Duration.ofSeconds(1));
+        Film film = new Film(
+                "new-catalog-id", "BR", "Anna, Nina, Pia und die wilden Tiere",
+                "Die Raubkatzen von Brasilien", "", 1700000000, 1400, 1,
+                "", "", "https://example.test/unreachable.mp4", "", "");
+
+        assertNull(service.download(film, tempDirectory, "Anna und die wilden Tiere",
+                Quality.HD, false, false));
+        assertEquals("existing-video", Files.readString(existing));
+        assertTrue(history.list(10).isEmpty());
+    }
+
     private static Film film(String id, String videoUrl) {
         return new Film(
                 id, "WDR", "Die Maus", "Eine Folge: Test?", "Description",

--- a/headless/src/test/java/mediathek/headless/HeadlessHttpServerTest.java
+++ b/headless/src/test/java/mediathek/headless/HeadlessHttpServerTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 MediathekView contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package mediathek.headless;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HeadlessHttpServerTest {
+    @TempDir
+    Path tempDirectory;
+
+    @Test
+    void rejectsDownloadsWhenOutputDirectoryIsBlank() throws Exception {
+        HistoryStore history = new HistoryStore(tempDirectory.resolve("state/history.db"));
+        MediathekViewWebClient client = new MediathekViewWebClient(
+                URI.create("http://127.0.0.1:1"), Duration.ofMillis(100));
+        DownloadService downloads = new DownloadService(history, Duration.ofSeconds(1));
+        SubscriptionService subscriptions = new SubscriptionService(client, downloads, history);
+        Model.SubscriptionConfig config = new Model.SubscriptionConfig("", List.of());
+
+        try (HeadlessHttpServer server = new HeadlessHttpServer(
+                "127.0.0.1", 0, client, downloads, history, subscriptions, config)) {
+            server.start();
+            HttpRequest request = HttpRequest.newBuilder(
+                            URI.create("http://127.0.0.1:" + server.port() + "/api/downloads"))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString("{\"id\":\"must-not-resolve\"}"))
+                    .build();
+
+            HttpResponse<String> response = HttpClient.newHttpClient().send(
+                    request, HttpResponse.BodyHandlers.ofString());
+
+            assertEquals(409, response.statusCode());
+            assertEquals("Server has no subscription config/outputDirectory",
+                    JsonSupport.MAPPER.readTree(response.body()).get("error").asText());
+        }
+    }
+}

--- a/headless/src/test/java/mediathek/headless/LibraryIndexTest.java
+++ b/headless/src/test/java/mediathek/headless/LibraryIndexTest.java
@@ -23,50 +23,86 @@ class LibraryIndexTest {
 
     @Test
     void recognizesLegacyProgramPrefixesAndIds() throws Exception {
+        String sourceUrl = "https://example.test/video.mp4";
         Path directory = Files.createDirectories(
                 tempDirectory.resolve("Anna, Nina, Pia und die wilden Tiere"));
         Path video = Files.writeString(directory.resolve(
-                "Anna, Nina, Pia und die wilden Tiere-Die Raubkatzen von Brasilien-1011316568.mp4"),
+                "Anna, Nina, Pia und die wilden Tiere-Die Raubkatzen von Brasilien-0557530028.mp4"),
                 "video");
 
         LibraryIndex index = LibraryIndex.scan(tempDirectory);
 
-        assertEquals(video, index.find(film("Die Raubkatzen von Brasilien")).orElseThrow());
+        assertEquals(video, index.find(film("Die Raubkatzen von Brasilien", sourceUrl)).orElseThrow());
     }
 
     @Test
     void recognizesDatedAndContentCategoryFilenames() throws Exception {
+        String datedUrl = "https://example.test/heilige-birma.mp4";
         Path datedDirectory = Files.createDirectories(tempDirectory.resolve("Anna und die Haustiere"));
         Path dated = Files.writeString(
-                datedDirectory.resolve("2026-08-08 - Heilige Birma.mp4"), "video");
+                datedDirectory.resolve("2026-08-08 - Heilige Birma [src-"
+                        + EpisodeIdentity.sourceFingerprint(datedUrl) + "].mp4"), "video");
+        String categoryUrl = "https://example.test/sonnenmilch.mp4";
         Path mausDirectory = Files.createDirectories(tempDirectory.resolve("Die Sendung mit der Maus"));
         Path category = Files.writeString(mausDirectory.resolve(
-                "Die Sendung mit der Maus-Sachgeschichte_ Sonnenmilch-1316812142.mp4"), "video");
+                "Die Sendung mit der Maus-Sachgeschichte_ Sonnenmilch-"
+                        + EpisodeIdentity.legacySourceHash(categoryUrl) + ".mp4"), "video");
 
         LibraryIndex index = LibraryIndex.scan(tempDirectory);
 
-        assertEquals(dated, index.find(film("Heilige Birma")).orElseThrow());
-        assertEquals(category, index.find(film("Sonnenmilch")).orElseThrow());
+        assertEquals(dated, index.find(film("Heilige Birma", datedUrl)).orElseThrow());
+        assertEquals(category, index.find(film("Sonnenmilch", categoryUrl)).orElseThrow());
     }
 
     @Test
     void ignoresPartialFilesAndKeepsAccessibilityEditionsDistinct() throws Exception {
+        String partialUrl = "https://example.test/new-episode.mp4";
         Path directory = Files.createDirectories(tempDirectory.resolve("Die Sendung mit der Maus"));
-        Files.writeString(directory.resolve("2026-08-09 - Neue Folge.mp4.part.mp4"), "partial");
+        Files.writeString(directory.resolve("2026-08-09 - Neue Folge [src-"
+                + EpisodeIdentity.sourceFingerprint(partialUrl) + "].mp4.part.mp4"), "partial");
+        String accessibleUrl = "https://example.test/frankreich-ad.mp4";
         Files.writeString(directory.resolve(
-                "Die Sendung mit der Maus-MausSpezial_ Frankreich-Maus - Audiodeskription-0096140127.mp4"),
+                "Die Sendung mit der Maus-MausSpezial_ Frankreich-Maus - Audiodeskription-"
+                        + EpisodeIdentity.legacySourceHash(accessibleUrl) + ".mp4"),
                 "video");
 
         LibraryIndex index = LibraryIndex.scan(tempDirectory);
 
-        assertTrue(index.find(film("Neue Folge")).isEmpty());
-        assertTrue(index.find(film("Frankreich-Maus")).isEmpty());
-        assertTrue(index.find(film("Frankreich-Maus - Audiodeskription")).isPresent());
+        assertTrue(index.find(film("Neue Folge", partialUrl)).isEmpty());
+        assertTrue(index.find(film("Frankreich-Maus", accessibleUrl)).isEmpty());
+        assertTrue(index.find(film("Frankreich-Maus - Audiodeskription", accessibleUrl)).isPresent());
     }
 
-    private static Model.Film film(String title) {
+    @Test
+    void keepsRecurringTitleOnlyEpisodesDistinct() throws Exception {
+        String existingUrl = "https://example.test/news/first.mp4";
+        Path directory = Files.createDirectories(tempDirectory.resolve("News"));
+        Path existing = Files.writeString(directory.resolve("2026-08-14 - Bulletin [src-"
+                + EpisodeIdentity.sourceFingerprint(existingUrl) + "].mp4"), "video");
+        Files.writeString(directory.resolve("2026-08-13 - Ambiguous Bulletin.mp4"), "ambiguous");
+
+        LibraryIndex index = LibraryIndex.scan(tempDirectory);
+
+        assertEquals(existing, index.find(film("Bulletin", existingUrl)).orElseThrow());
+        assertTrue(index.find(film("Bulletin", "https://example.test/news/second.mp4")).isEmpty());
+        assertTrue(index.find(film("Ambiguous Bulletin", "https://example.test/news/ambiguous.mp4")).isEmpty());
+    }
+
+    @Test
+    void usesImmediateParentForNestedLegacyNames() throws Exception {
+        String sourceUrl = "https://example.test/show/episode.mp4";
+        Path directory = Files.createDirectories(tempDirectory.resolve("category/Show"));
+        Path video = Files.writeString(directory.resolve("Show-Episode-"
+                + EpisodeIdentity.legacySourceHash(sourceUrl) + ".mp4"), "video");
+
+        LibraryIndex index = LibraryIndex.scan(tempDirectory);
+
+        assertEquals(video, index.find(film("Episode", sourceUrl)).orElseThrow());
+    }
+
+    private static Model.Film film(String title, String sourceUrl) {
         return new Model.Film(
                 "id", "BR", "Topic", title, "", 1700000000, 1200, 1,
-                "", "", "https://example.test/video.mp4", "", "");
+                "", "", sourceUrl, "", "");
     }
 }

--- a/headless/src/test/java/mediathek/headless/LibraryIndexTest.java
+++ b/headless/src/test/java/mediathek/headless/LibraryIndexTest.java
@@ -54,14 +54,14 @@ class LibraryIndexTest {
         Path directory = Files.createDirectories(tempDirectory.resolve("Die Sendung mit der Maus"));
         Files.writeString(directory.resolve("2026-08-09 - Neue Folge.mp4.part.mp4"), "partial");
         Files.writeString(directory.resolve(
-                "Die Sendung mit der Maus-MausSpezial_ Frankreich-Maus - Hörfassung-0096140127.mp4"),
+                "Die Sendung mit der Maus-MausSpezial_ Frankreich-Maus - Audiodeskription-0096140127.mp4"),
                 "video");
 
         LibraryIndex index = LibraryIndex.scan(tempDirectory);
 
         assertTrue(index.find(film("Neue Folge")).isEmpty());
         assertTrue(index.find(film("Frankreich-Maus")).isEmpty());
-        assertTrue(index.find(film("Frankreich-Maus - Hörfassung")).isPresent());
+        assertTrue(index.find(film("Frankreich-Maus - Audiodeskription")).isPresent());
     }
 
     private static Model.Film film(String title) {

--- a/headless/src/test/java/mediathek/headless/LibraryIndexTest.java
+++ b/headless/src/test/java/mediathek/headless/LibraryIndexTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 MediathekView contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package mediathek.headless;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LibraryIndexTest {
+    @TempDir
+    Path tempDirectory;
+
+    @Test
+    void recognizesLegacyProgramPrefixesAndIds() throws Exception {
+        Path directory = Files.createDirectories(
+                tempDirectory.resolve("Anna, Nina, Pia und die wilden Tiere"));
+        Path video = Files.writeString(directory.resolve(
+                "Anna, Nina, Pia und die wilden Tiere-Die Raubkatzen von Brasilien-1011316568.mp4"),
+                "video");
+
+        LibraryIndex index = LibraryIndex.scan(tempDirectory);
+
+        assertEquals(video, index.find(film("Die Raubkatzen von Brasilien")).orElseThrow());
+    }
+
+    @Test
+    void recognizesDatedAndContentCategoryFilenames() throws Exception {
+        Path datedDirectory = Files.createDirectories(tempDirectory.resolve("Anna und die Haustiere"));
+        Path dated = Files.writeString(
+                datedDirectory.resolve("2026-08-08 - Heilige Birma.mp4"), "video");
+        Path mausDirectory = Files.createDirectories(tempDirectory.resolve("Die Sendung mit der Maus"));
+        Path category = Files.writeString(mausDirectory.resolve(
+                "Die Sendung mit der Maus-Sachgeschichte_ Sonnenmilch-1316812142.mp4"), "video");
+
+        LibraryIndex index = LibraryIndex.scan(tempDirectory);
+
+        assertEquals(dated, index.find(film("Heilige Birma")).orElseThrow());
+        assertEquals(category, index.find(film("Sonnenmilch")).orElseThrow());
+    }
+
+    @Test
+    void ignoresPartialFilesAndKeepsAccessibilityEditionsDistinct() throws Exception {
+        Path directory = Files.createDirectories(tempDirectory.resolve("Die Sendung mit der Maus"));
+        Files.writeString(directory.resolve("2026-08-09 - Neue Folge.mp4.part.mp4"), "partial");
+        Files.writeString(directory.resolve(
+                "Die Sendung mit der Maus-MausSpezial_ Frankreich-Maus - Hörfassung-0096140127.mp4"),
+                "video");
+
+        LibraryIndex index = LibraryIndex.scan(tempDirectory);
+
+        assertTrue(index.find(film("Neue Folge")).isEmpty());
+        assertTrue(index.find(film("Frankreich-Maus")).isEmpty());
+        assertTrue(index.find(film("Frankreich-Maus - Hörfassung")).isPresent());
+    }
+
+    private static Model.Film film(String title) {
+        return new Model.Film(
+                "id", "BR", "Topic", title, "", 1700000000, 1200, 1,
+                "", "", "https://example.test/video.mp4", "", "");
+    }
+}

--- a/headless/src/test/java/mediathek/headless/MediathekViewWebClientTest.java
+++ b/headless/src/test/java/mediathek/headless/MediathekViewWebClientTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 MediathekView contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package mediathek.headless;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+
+import static mediathek.headless.Model.QueryClause;
+import static mediathek.headless.Model.SearchRequest;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MediathekViewWebClientTest {
+    private HttpServer server;
+    private MediathekViewWebClient client;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/api/query", exchange -> send(exchange, """
+                {"result":{"results":[{
+                  "id":"film-id","channel":"WDR","topic":"Die Maus","title":"Folge 1",
+                  "description":"Test","timestamp":1700000000,"duration":1800,"size":123,
+                  "url_website":"https://example.test/page","url_subtitle":"",
+                  "url_video":"https://example.test/video.mp4","url_video_low":"","url_video_hd":""
+                }],"queryInfo":{"filmlisteTimestamp":1700000100,"searchEngineTime":"1.25",
+                  "resultCount":1,"totalResults":1,"totalRelation":"eq","totalEntries":700000}},"err":null}
+                """));
+        server.createContext("/api/entries", exchange -> send(exchange, """
+                {"result":{"results":[{
+                  "id":"film-id","channel":"WDR","topic":"Die Maus","title":"Folge 1",
+                  "description":"Test","timestamp":1700000000,"duration":1800,"size":123,
+                  "url_website":"https://example.test/page","url_subtitle":"",
+                  "url_video":"https://example.test/video.mp4","url_video_low":"","url_video_hd":""
+                }]},"err":null}
+                """));
+        server.start();
+        URI baseUri = URI.create("http://127.0.0.1:" + server.getAddress().getPort());
+        client = new MediathekViewWebClient(baseUri, Duration.ofSeconds(5));
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop(0);
+    }
+
+    @Test
+    void searchesAndMapsSnakeCaseFields() throws Exception {
+        SearchRequest request = new SearchRequest(
+                List.of(new QueryClause(List.of("title", "topic"), "Maus")),
+                "timestamp", "desc", false, 0, 10, null, null);
+
+        var result = client.search(request);
+
+        assertEquals(1, result.results().size());
+        assertEquals("film-id", result.results().get(0).id());
+        assertEquals("https://example.test/video.mp4", result.results().get(0).videoUrl());
+        assertEquals(700000, result.queryInfo().totalEntries());
+    }
+
+    @Test
+    void resolvesExactEntryId() throws Exception {
+        var film = client.entry("film-id");
+
+        assertEquals("Folge 1", film.title());
+    }
+
+    private static void send(HttpExchange exchange, String json) throws IOException {
+        assertEquals("POST", exchange.getRequestMethod());
+        assertTrue(exchange.getRequestBody().readAllBytes().length > 0);
+        byte[] body = json.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, body.length);
+        exchange.getResponseBody().write(body);
+        exchange.close();
+    }
+}

--- a/headless/src/test/java/mediathek/headless/MediathekViewWebClientTest.java
+++ b/headless/src/test/java/mediathek/headless/MediathekViewWebClientTest.java
@@ -44,7 +44,7 @@ class MediathekViewWebClientTest {
                 """));
         server.createContext("/api/entries", exchange -> send(exchange, """
                 {"result":{"results":[{
-                  "id":"film-id","channel":"WDR","topic":"Die Maus","title":"Folge 1",
+                  "id":null,"channel":"WDR","topic":"Die Maus","title":"Folge 1",
                   "description":"Test","timestamp":1700000000,"duration":1800,"size":123,
                   "url_website":"https://example.test/page","url_subtitle":"",
                   "url_video":"https://example.test/video.mp4","url_video_low":"","url_video_hd":""
@@ -78,6 +78,7 @@ class MediathekViewWebClientTest {
     void resolvesExactEntryId() throws Exception {
         var film = client.entry("film-id");
 
+        assertEquals("film-id", film.id());
         assertEquals("Folge 1", film.title());
     }
 

--- a/headless/src/test/java/mediathek/headless/ModelTest.java
+++ b/headless/src/test/java/mediathek/headless/ModelTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 MediathekView contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package mediathek.headless;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static mediathek.headless.Model.Film;
+import static mediathek.headless.Model.Quality;
+import static mediathek.headless.Model.SearchRequest;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ModelTest {
+    @Test
+    void serializesMediathekViewWebDurationFieldNames() {
+        SearchRequest request = new SearchRequest(List.of(), "timestamp", "desc", false, 0, 20, 60, 3600);
+
+        String json = JsonSupport.write(request);
+
+        assertTrue(json.contains("\"duration_min\":60"));
+        assertTrue(json.contains("\"duration_max\":3600"));
+    }
+
+    @Test
+    void qualityFallsBackWhenPreferredUrlIsMissing() {
+        Film film = new Film("id", "WDR", "topic", "title", "", 0, 0, 0,
+                "", "", "https://example.test/sd.mp4", "", "");
+
+        assertEquals("https://example.test/sd.mp4", Quality.HD.selectUrl(film));
+        assertEquals(Quality.LOW, Quality.parse("lq"));
+    }
+}

--- a/headless/src/test/java/mediathek/headless/SubscriptionServiceTest.java
+++ b/headless/src/test/java/mediathek/headless/SubscriptionServiceTest.java
@@ -59,6 +59,9 @@ class SubscriptionServiceTest {
         server.start();
 
         Path output = Files.createDirectory(tempDirectory.resolve("output"));
+        Path existingDirectory = Files.createDirectory(output.resolve("Die Sendung mit der Maus"));
+        Files.writeString(existingDirectory.resolve(
+                "2026-08-02 - Die Sendung mit der Maus vom 02.08.2026.mp4"), "existing");
         HistoryStore history = new HistoryStore(tempDirectory.resolve("state/history.db"));
         MediathekViewWebClient client = new MediathekViewWebClient(
                 URI.create("http://127.0.0.1:" + server.getAddress().getPort()), Duration.ofSeconds(5));
@@ -84,10 +87,12 @@ class SubscriptionServiceTest {
         assertEquals(2, plan.matched());
         assertEquals(List.of("older-standard", "latest-standard"),
                 plan.selections().stream().map(Model.SyncSelection::id).toList());
-        assertTrue(plan.selections().stream().allMatch(item -> item.status().equals("would-download")));
+        assertEquals(List.of("already-in-library", "would-download"),
+                plan.selections().stream().map(Model.SyncSelection::status).toList());
+        assertEquals(1, plan.skipped());
         assertTrue(history.list(10).isEmpty());
-        try (var children = Files.list(output)) {
-            assertTrue(children.findAny().isEmpty());
+        try (var files = Files.walk(output)) {
+            assertEquals(1, files.filter(Files::isRegularFile).count());
         }
     }
 

--- a/headless/src/test/java/mediathek/headless/SubscriptionServiceTest.java
+++ b/headless/src/test/java/mediathek/headless/SubscriptionServiceTest.java
@@ -61,7 +61,9 @@ class SubscriptionServiceTest {
         Path output = Files.createDirectory(tempDirectory.resolve("output"));
         Path existingDirectory = Files.createDirectory(output.resolve("Die Sendung mit der Maus"));
         Files.writeString(existingDirectory.resolve(
-                "2026-08-02 - Die Sendung mit der Maus vom 02.08.2026.mp4"), "existing");
+                "2026-08-02 - Die Sendung mit der Maus vom 02.08.2026 [src-"
+                        + EpisodeIdentity.sourceFingerprint("https://example.test/older.mp4") + "].mp4"),
+                "existing");
         HistoryStore history = new HistoryStore(tempDirectory.resolve("state/history.db"));
         MediathekViewWebClient client = new MediathekViewWebClient(
                 URI.create("http://127.0.0.1:" + server.getAddress().getPort()), Duration.ofSeconds(5));
@@ -115,6 +117,41 @@ class SubscriptionServiceTest {
         assertTrue(plan.selections().isEmpty());
         assertEquals(1, plan.errors().size());
         assertTrue(plan.errors().get(0).contains("includeTitleRegex is invalid"));
+    }
+
+    @Test
+    void rejectsDuplicateSubscriptionNamesBeforeQueryingOrDownloading() throws Exception {
+        Path output = Files.createDirectory(tempDirectory.resolve("output"));
+        HistoryStore history = new HistoryStore(tempDirectory.resolve("state/history.db"));
+        MediathekViewWebClient client = new MediathekViewWebClient(
+                URI.create("http://127.0.0.1:1"), Duration.ofMillis(100));
+        SubscriptionService service = new SubscriptionService(
+                client, new DownloadService(history, Duration.ofSeconds(1)), history);
+        Subscription first = new Subscription(
+                "Duplicate",
+                List.of(new QueryClause(List.of("topic"), "First")),
+                "first", "HD", 1, null, null, false, true,
+                null, null, null, null);
+        Subscription second = new Subscription(
+                "Duplicate",
+                List.of(new QueryClause(List.of("topic"), "Second")),
+                "second", "LOW", 1, null, null, false, false,
+                null, null, null, null);
+        SubscriptionConfig config = new SubscriptionConfig(output.toString(), List.of(first, second));
+
+        var plan = service.plan(config);
+        var result = service.sync(config);
+
+        assertEquals(List.of("Duplicate subscription name: Duplicate"), plan.errors());
+        assertTrue(plan.selections().isEmpty());
+        assertEquals(0, plan.matched());
+        assertEquals(List.of("Duplicate subscription name: Duplicate"), result.errors());
+        assertEquals(0, result.downloaded());
+        assertEquals(0, result.matched());
+        assertTrue(history.list(10).isEmpty());
+        try (var files = Files.walk(output)) {
+            assertEquals(0, files.filter(Files::isRegularFile).count());
+        }
     }
 
     private static void send(HttpExchange exchange, String json) throws IOException {

--- a/headless/src/test/java/mediathek/headless/SubscriptionServiceTest.java
+++ b/headless/src/test/java/mediathek/headless/SubscriptionServiceTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 MediathekView contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package mediathek.headless;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+
+import static mediathek.headless.Model.QueryClause;
+import static mediathek.headless.Model.Subscription;
+import static mediathek.headless.Model.SubscriptionConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SubscriptionServiceTest {
+    @TempDir
+    Path tempDirectory;
+
+    private HttpServer server;
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void filtersBeforeApplyingLimitAndDryRunDoesNotDownload() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/api/query", exchange -> send(exchange, """
+                {"result":{"results":[
+                  {"id":"latest-ad","channel":"WDR","topic":"Die Sendung mit der Maus","title":"Die Sendung mit der Maus vom 09.08.2026 (Audiodeskription)","description":"","timestamp":600,"duration":1800,"size":1,"url_website":"","url_subtitle":"","url_video":"https://example.test/ad.mp4","url_video_low":"","url_video_hd":""},
+                  {"id":"latest-sign","channel":"WDR","topic":"Die Sendung mit der Maus","title":"Die Sendung mit der Maus vom 09.08.2026 (Gebärdensprache)","description":"","timestamp":600,"duration":1800,"size":1,"url_website":"","url_subtitle":"","url_video":"https://example.test/sign.mp4","url_video_low":"","url_video_hd":""},
+                  {"id":"latest-standard","channel":"WDR","topic":"Die Sendung mit der Maus","title":"Die Sendung mit der Maus vom 09.08.2026","description":"","timestamp":600,"duration":1800,"size":1,"url_website":"","url_subtitle":"","url_video":"https://example.test/latest.mp4","url_video_low":"","url_video_hd":""},
+                  {"id":"latest-standard-copy","channel":"ARD","topic":"Die Sendung mit der Maus","title":"Die Sendung mit der Maus vom 09.08.2026","description":"","timestamp":600,"duration":1800,"size":1,"url_website":"","url_subtitle":"","url_video":"https://example.test/latest.mp4","url_video_low":"","url_video_hd":""},
+                  {"id":"older-ad","channel":"WDR","topic":"Die Sendung mit der Maus","title":"Die Sendung mit der Maus vom 02.08.2026 (Audiodeskription)","description":"","timestamp":500,"duration":1800,"size":1,"url_website":"","url_subtitle":"","url_video":"https://example.test/older-ad.mp4","url_video_low":"","url_video_hd":""},
+                  {"id":"older-standard","channel":"WDR","topic":"Die Sendung mit der Maus","title":"Die Sendung mit der Maus vom 02.08.2026","description":"","timestamp":500,"duration":1800,"size":1,"url_website":"","url_subtitle":"","url_video":"https://example.test/older.mp4","url_video_low":"","url_video_hd":""},
+                  {"id":"segment","channel":"WDR","topic":"Die Sendung mit der Maus","title":"Apfelstiel","description":"","timestamp":400,"duration":300,"size":1,"url_website":"","url_subtitle":"","url_video":"https://example.test/segment.mp4","url_video_low":"","url_video_hd":""}
+                ],"queryInfo":{"filmlisteTimestamp":700,"searchEngineTime":"1","resultCount":7,"totalResults":7,"totalRelation":"eq","totalEntries":7}},"err":null}
+                """));
+        server.start();
+
+        Path output = Files.createDirectory(tempDirectory.resolve("output"));
+        HistoryStore history = new HistoryStore(tempDirectory.resolve("state/history.db"));
+        MediathekViewWebClient client = new MediathekViewWebClient(
+                URI.create("http://127.0.0.1:" + server.getAddress().getPort()), Duration.ofSeconds(5));
+        SubscriptionService service = new SubscriptionService(
+                client, new DownloadService(history, Duration.ofSeconds(5)), history);
+        Subscription subscription = new Subscription(
+                "Maus",
+                List.of(new QueryClause(List.of("topic"), "Die Sendung mit der Maus")),
+                "Maus",
+                "HD",
+                2,
+                1200,
+                null,
+                false,
+                true,
+                "^Die Sendung mit der Maus vom",
+                "\\((Audiodeskription|Gebärdensprache)\\)",
+                null,
+                null);
+
+        var plan = service.plan(new SubscriptionConfig(output.toString(), List.of(subscription)));
+
+        assertEquals(2, plan.matched());
+        assertEquals(List.of("older-standard", "latest-standard"),
+                plan.selections().stream().map(Model.SyncSelection::id).toList());
+        assertTrue(plan.selections().stream().allMatch(item -> item.status().equals("would-download")));
+        assertTrue(history.list(10).isEmpty());
+        try (var children = Files.list(output)) {
+            assertTrue(children.findAny().isEmpty());
+        }
+    }
+
+    @Test
+    void reportsInvalidRegexWithoutQuerying() throws Exception {
+        Path output = Files.createDirectory(tempDirectory.resolve("output"));
+        HistoryStore history = new HistoryStore(tempDirectory.resolve("state/history.db"));
+        MediathekViewWebClient client = new MediathekViewWebClient(
+                URI.create("http://127.0.0.1:1"), Duration.ofMillis(100));
+        SubscriptionService service = new SubscriptionService(
+                client, new DownloadService(history, Duration.ofSeconds(1)), history);
+        Subscription subscription = new Subscription(
+                "Broken",
+                List.of(new QueryClause(List.of("topic"), "Maus")),
+                "Maus", "HD", 1, null, null, false, true,
+                "[", null, null, null);
+
+        var plan = service.plan(new SubscriptionConfig(output.toString(), List.of(subscription)));
+
+        assertTrue(plan.selections().isEmpty());
+        assertEquals(1, plan.errors().size());
+        assertTrue(plan.errors().get(0).contains("includeTitleRegex is invalid"));
+    }
+
+    private static void send(HttpExchange exchange, String json) throws IOException {
+        assertEquals("POST", exchange.getRequestMethod());
+        exchange.getRequestBody().readAllBytes();
+        byte[] body = json.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, body.length);
+        exchange.getResponseBody().write(body);
+        exchange.close();
+    }
+}

--- a/headless/subscriptions.example.json
+++ b/headless/subscriptions.example.json
@@ -1,0 +1,24 @@
+{
+  "outputDirectory": "/mnt/nas-china-01/Kinder/Video/MediathekView-Downloads",
+  "subscriptions": [
+    {
+      "name": "Die Sendung mit der Maus",
+      "queries": [
+        {
+          "fields": ["channel"],
+          "query": "WDR"
+        },
+        {
+          "fields": ["topic", "title"],
+          "query": "Die Sendung mit der Maus"
+        }
+      ],
+      "subdirectory": "Die Sendung mit der Maus",
+      "quality": "HD",
+      "maxResults": 1,
+      "minDuration": 300,
+      "includeFuture": false,
+      "subtitles": true
+    }
+  ]
+}

--- a/headless/subscriptions.example.json
+++ b/headless/subscriptions.example.json
@@ -1,5 +1,5 @@
 {
-  "outputDirectory": "/mnt/nas-china-01/Kinder/Video/MediathekView-Downloads",
+  "outputDirectory": "/mnt/nas-china-01/Kinder/Video/Mediathek",
   "subscriptions": [
     {
       "name": "Die Sendung mit der Maus",

--- a/headless/subscriptions.example.json
+++ b/headless/subscriptions.example.json
@@ -9,13 +9,125 @@
           "query": "WDR"
         },
         {
-          "fields": ["topic", "title"],
+          "fields": ["topic"],
           "query": "Die Sendung mit der Maus"
+        },
+        {
+          "fields": ["title"],
+          "query": "Die Sendung mit der Maus vom"
         }
       ],
+      "includeTitleRegex": "^Die Sendung mit der Maus vom [0-9]{2}\\.[0-9]{2}\\.[0-9]{4}",
+      "excludeTitleRegex": "\\((Audiodeskription|Gebärdensprache)\\)",
       "subdirectory": "Die Sendung mit der Maus",
       "quality": "HD",
-      "maxResults": 1,
+      "maxResults": 3,
+      "minDuration": 1200,
+      "includeFuture": false,
+      "subtitles": true
+    },
+    {
+      "name": "Anna und die wilden Tiere",
+      "queries": [
+        {
+          "fields": ["topic"],
+          "query": "Anna wilden Tiere"
+        }
+      ],
+      "subdirectory": "Anna und die wilden Tiere",
+      "quality": "HD",
+      "maxResults": 3,
+      "minDuration": 300,
+      "includeFuture": false,
+      "subtitles": true
+    },
+    {
+      "name": "Anna und die Haustiere",
+      "queries": [
+        {
+          "fields": ["topic"],
+          "query": "Anna Haustiere"
+        }
+      ],
+      "subdirectory": "Anna und die Haustiere",
+      "quality": "HD",
+      "maxResults": 3,
+      "minDuration": 300,
+      "includeFuture": false,
+      "subtitles": true
+    },
+    {
+      "name": "Pia und die wilde Natur",
+      "queries": [
+        {
+          "fields": ["topic"],
+          "query": "wilde Natur"
+        }
+      ],
+      "includeTopicRegex": "^(Pia und die wilde Natur|Die wilde Natur|Anna, Paula, Pia und die wilden Tiere / wilde Natur)$",
+      "subdirectory": "Pia und die wilde Natur",
+      "quality": "HD",
+      "maxResults": 3,
+      "minDuration": 300,
+      "includeFuture": false,
+      "subtitles": true
+    },
+    {
+      "name": "Anna und das wilde Wissen",
+      "queries": [
+        {
+          "fields": ["topic"],
+          "query": "Anna, Pia und das wilde Wissen"
+        }
+      ],
+      "subdirectory": "Anna und das wilde Wissen",
+      "quality": "HD",
+      "maxResults": 3,
+      "minDuration": 300,
+      "includeFuture": false,
+      "subtitles": true
+    },
+    {
+      "name": "Frag Anna",
+      "queries": [
+        {
+          "fields": ["topic"],
+          "query": "Frag Anna"
+        }
+      ],
+      "includeTopicRegex": "^Frag Anna!$",
+      "subdirectory": "Frag Anna",
+      "quality": "HD",
+      "maxResults": 3,
+      "includeFuture": false,
+      "subtitles": true
+    },
+    {
+      "name": "Anna und die wilden Lieder",
+      "queries": [
+        {
+          "fields": ["topic"],
+          "query": "Anna wilden Lieder"
+        }
+      ],
+      "subdirectory": "Anna und die wilden Lieder",
+      "quality": "HD",
+      "maxResults": 3,
+      "includeFuture": false,
+      "subtitles": true
+    },
+    {
+      "name": "Anna Spezialserien",
+      "queries": [
+        {
+          "fields": ["topic"],
+          "query": "Anna"
+        }
+      ],
+      "includeTopicRegex": "^Anna (auf dem Bauernhof|auf der Alm|im Land der tausend Seen|lernt reiten|und der wilde Wald|und die wilde (Herde|Hilde))$",
+      "subdirectory": "Anna Spezialserien",
+      "quality": "HD",
+      "maxResults": 3,
       "minDuration": 300,
       "includeFuture": false,
       "subtitles": true

--- a/headless/systemd/mediathekview-headless-api.service
+++ b/headless/systemd/mediathekview-headless-api.service
@@ -14,6 +14,7 @@ StateDirectory=mediathekview-headless
 ExecStart=/usr/bin/java --enable-native-access=ALL-UNNAMED -jar /opt/mediathekview-headless/mediathekview-headless.jar --state /var/lib/mediathekview-headless/history.db serve --bind 127.0.0.1 --port 7070 --config /etc/mediathekview-headless/subscriptions.json
 Restart=on-failure
 RestartSec=10s
+SuccessExitStatus=143
 NoNewPrivileges=true
 PrivateTmp=true
 PrivateDevices=true

--- a/headless/systemd/mediathekview-headless-api.service
+++ b/headless/systemd/mediathekview-headless-api.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=MediathekView Headless API
+Documentation=https://github.com/mediathekview/MediathekView/tree/master/headless
+Wants=network-online.target
+After=network-online.target remote-fs.target
+RequiresMountsFor=/mnt/nas-china-01/Kinder
+ConditionPathIsMountPoint=/mnt/nas-china-01/Kinder
+
+[Service]
+Type=simple
+User=admin
+Group=admin
+StateDirectory=mediathekview-headless
+ExecStart=/usr/bin/java --enable-native-access=ALL-UNNAMED -jar /opt/mediathekview-headless/mediathekview-headless.jar --state /var/lib/mediathekview-headless/history.db serve --bind 127.0.0.1 --port 7070 --config /etc/mediathekview-headless/subscriptions.json
+Restart=on-failure
+RestartSec=10s
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectHome=true
+ProtectSystem=strict
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+ReadWritePaths=/mnt/nas-china-01/Kinder/Video/MediathekView-Downloads
+
+[Install]
+WantedBy=multi-user.target

--- a/headless/systemd/mediathekview-headless-api.service
+++ b/headless/systemd/mediathekview-headless-api.service
@@ -10,6 +10,7 @@ ConditionPathIsMountPoint=/mnt/nas-china-01/Kinder
 Type=simple
 User=admin
 Group=admin
+Environment=LANG=C.UTF-8
 StateDirectory=mediathekview-headless
 ExecStart=/usr/bin/java --enable-native-access=ALL-UNNAMED -jar /opt/mediathekview-headless/mediathekview-headless.jar --state /var/lib/mediathekview-headless/history.db serve --bind 127.0.0.1 --port 7070 --config /etc/mediathekview-headless/subscriptions.json
 Restart=on-failure

--- a/headless/systemd/mediathekview-headless-api.service
+++ b/headless/systemd/mediathekview-headless-api.service
@@ -22,7 +22,7 @@ ProtectSystem=strict
 ProtectKernelTunables=true
 ProtectKernelModules=true
 ProtectControlGroups=true
-ReadWritePaths=/mnt/nas-china-01/Kinder/Video/MediathekView-Downloads
+ReadWritePaths=/mnt/nas-china-01/Kinder/Video/Mediathek
 
 [Install]
 WantedBy=multi-user.target

--- a/headless/systemd/mediathekview-headless-sync.service
+++ b/headless/systemd/mediathekview-headless-sync.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Queue MediathekView Headless subscription sync
+Requires=mediathekview-headless-api.service
+After=mediathekview-headless-api.service
+
+[Service]
+Type=oneshot
+User=admin
+Group=admin
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ExecStart=/usr/bin/curl --fail --silent --show-error --retry 5 --retry-connrefused --retry-delay 2 --request POST http://127.0.0.1:7070/api/sync

--- a/headless/systemd/mediathekview-headless-sync.timer
+++ b/headless/systemd/mediathekview-headless-sync.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run MediathekView Headless subscriptions hourly
+
+[Timer]
+OnCalendar=hourly
+RandomizedDelaySec=5m
+Persistent=true
+Unit=mediathekview-headless-sync.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

- add a standalone Java 17 CLI and local HTTP API for catalog search, exact entry lookup, downloads, history, and subscriptions
- provide atomic progressive and HLS downloads with bounded network/process timeouts and source-aware library deduplication
- include OpenAPI documentation, example subscription config, systemd units, and regression coverage

## Testing

- JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ./mvnw -f headless/pom.xml clean verify
- 17 tests passed